### PR TITLE
Unallow to delete a blueprint in usage into a test section

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label'       => 'Blueprints Extension',
     'description' => 'Extension to manage Test Blueprints',
     'license'     => 'GPL-2.0',
-    'version'     => '0.6.1',
+    'version'     => '0.6.2',
     'author'      => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=7.35.0'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -55,6 +55,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.4.0');
         }
 
-        $this->skip('0.4.0', '0.6.1');
+        $this->skip('0.4.0', '0.6.2');
     }
 }


### PR DESCRIPTION
Unallow to delete a blueprint in usage into a test section section.
To test it:
- Install blueprint extension
- Create an item property 'langTest' (dropdown with lang)
- Create a blueprint with target property for property 'langTest' (add some itemCount)
- Add an identifier to this blueprint
- Create a test
- Add a blueprint to a test SECTION parameters
- Try to delete the blueprint, tou should be unable to delete it