### PR TITLE
feature/TAO-7629 qunit 2 migration

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,10 +27,10 @@ return array(
     'label'       => 'Blueprints Extension',
     'description' => 'Extension to manage Test Blueprints',
     'license'     => 'GPL-2.0',
-    'version'     => '2.1.1',
+    'version'     => '2.2.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires' => [
-        'tao' => '>=21.15.0'
+        'tao' => '>=30.0.0'
     ],
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoBlueprintsManager',
     'acl' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label'       => 'Blueprints Extension',
     'description' => 'Extension to manage Test Blueprints',
     'license'     => 'GPL-2.0',
-    'version'     => '2.1.0',
+    'version'     => '2.1.1',
     'author'      => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=21.15.0'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -55,6 +55,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.4.0');
         }
 
-        $this->skip('0.4.0', '2.1.1');
+        $this->skip('0.4.0', '2.2.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -55,6 +55,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.4.0');
         }
 
-        $this->skip('0.4.0', '2.1.0');
+        $this->skip('0.4.0', '2.1.1');
     }
 }

--- a/views/js/test/component/editor/distributor/test.html
+++ b/views/js/test/component/editor/distributor/test.html
@@ -6,8 +6,8 @@
         <base href="../../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="editor/distributor/distributor.js"></script>
 

--- a/views/js/test/component/editor/distributor/test.js
+++ b/views/js/test/component/editor/distributor/test.js
@@ -17,253 +17,260 @@
  */
 
 /**
- * Test the Blueprint Editor's distributor component
+ * Test the Blueprint Edito\'s distributor component
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-define([
+define( [
+    
     'jquery',
     'taoBlueprints/component/editor/distributor/distributor',
     'json!taoBlueprints/test/component/editor/distributor/data.json',
     'json!taoBlueprints/test/component/editor/distributor/empty.json'
-], function($, distributorComponent, samples, emptySamples) {
+], function(  $, distributorComponent, samples, emptySamples ) {
     'use strict';
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('module', function(assert) {
-        QUnit.expect(3);
+    QUnit.test( 'module', function( assert ) {
+        assert.expect( 3 );
 
-        assert.equal(typeof distributorComponent, 'function', "The distributorComponent module exposes a function");
-        assert.equal(typeof distributorComponent(), 'object', "The distributorComponent factory produces an object");
-        assert.notStrictEqual(distributorComponent(), distributorComponent(), "The distributorComponent factory provides a different object on each call");
-    });
+        assert.equal( typeof distributorComponent, 'function', 'The distributorComponent module exposes a function' );
+        assert.equal( typeof distributorComponent(), 'object', 'The distributorComponent factory produces an object' );
+        assert.notStrictEqual( distributorComponent(), distributorComponent(), 'The distributorComponent factory provides a different object on each call' );
+    } );
 
-    QUnit.cases([
-        { name : 'init',         title : 'init' },
-        { name : 'destroy',      title : 'destroy' },
-        { name : 'render',       title : 'render' },
-        { name : 'show',         title : 'show' },
-        { name : 'hide',         title : 'hide' },
-        { name : 'enable',       title : 'enable' },
-        { name : 'disable',      title : 'disable' },
-        { name : 'is',           title : 'is' },
-        { name : 'setState',     title : 'setState' },
-        { name : 'getContainer', title : 'getContainer' },
-        { name : 'getElement',   title : 'getElement' },
-        { name : 'getTemplate',  title : 'getTemplate' },
-        { name : 'setTemplate',  title : 'setTemplate' }
-    ])
-    .test('component ', function(data, assert) {
+    QUnit.cases.init( [
+        { name: 'init',         title: 'init' },
+        { name: 'destroy',      title: 'destroy' },
+        { name: 'render',       title: 'render' },
+        { name: 'show',         title: 'show' },
+        { name: 'hide',         title: 'hide' },
+        { name: 'enable',       title: 'enable' },
+        { name: 'disable',      title: 'disable' },
+        { name: 'is',           title: 'is' },
+        { name: 'setState',     title: 'setState' },
+        { name: 'getContainer', title: 'getContainer' },
+        { name: 'getElement',   title: 'getElement' },
+        { name: 'getTemplate',  title: 'getTemplate' },
+        { name: 'setTemplate',  title: 'setTemplate' }
+    ] )
+    .test( 'component ', function( data, assert ) {
         var instance = distributorComponent();
-        assert.equal(typeof instance[data.name], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function');
-    });
+        assert.equal( typeof instance[ data.name ], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function' );
+    } );
 
-    QUnit.cases([
-        { name : 'on',      title : 'on' },
-        { name : 'off',     title : 'off' },
-        { name : 'trigger', title : 'trigger' }
-    ])
-    .test('eventifier ', function(data, assert) {
+    QUnit.cases.init( [
+        { name: 'on',      title: 'on' },
+        { name: 'off',     title: 'off' },
+        { name: 'trigger', title: 'trigger' }
+    ] )
+    .test( 'eventifier ', function( data, assert ) {
         var instance = distributorComponent();
-        assert.equal(typeof instance[data.name], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function');
-    });
+        assert.equal( typeof instance[ data.name ], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function' );
+    } );
 
-    QUnit.cases([
-        { name : 'getValues', title : 'getValues' }
-    ])
-    .test('spec ', function(data, assert) {
+    QUnit.cases.init( [
+        { name: 'getValues', title: 'getValues' }
+    ] )
+    .test( 'spec ', function( data, assert ) {
         var instance = distributorComponent();
-        assert.equal(typeof instance[data.name], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function');
-    });
+        assert.equal( typeof instance[ data.name ], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function' );
+    } );
 
+    QUnit.module( 'Behavior' );
 
-    QUnit.module('Behavior');
+    QUnit.test( 'DOM rendering', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-    QUnit.asyncTest('DOM rendering', function(assert) {
-        var $container = $('#qunit-fixture');
+        assert.expect( 12 );
 
-        QUnit.expect(12);
+        distributorComponent( $container, { data: samples } )
+            .on( 'render', function() {
+                var $element = $( '.distributor', $container );
 
-        distributorComponent( $container, { data : samples } )
-            .on('render', function(){
-                var $element = $('.distributor', $container);
+                assert.equal( $element.length, 1, 'The container has the component root element' );
+                assert.ok( $element.hasClass( 'rendered' ), 1, 'The component root element has the rendered class' );
 
-                assert.equal($element.length, 1, 'The container has the component root element');
-                assert.ok($element.hasClass('rendered'), 1, 'The component root element has the rendered class');
+                assert.equal( $( 'header', $element ).length, 1, 'The component has an header element' );
+                assert.equal( $( 'ul', $element ).length, 1, 'The component has an list element' );
+                assert.equal( $( 'ul li', $element ).length, 5, 'The component has the correct number of items' );
 
-                assert.equal($('header', $element).length, 1, 'The component has an header element');
-                assert.equal($('ul', $element).length, 1, 'The component has an list element');
-                assert.equal($('ul li', $element).length, 5, 'The component has the correct number of items');
+                assert.equal( $( 'ul li:first-child', $element ).data( 'uri' ),  'http://www.my-tao.com#federalStateRegulation', 'The item has the correct URI' );
+                assert.equal( $( 'ul li:first-child .label', $element ).length, 1, 'The item has a label element' );
+                assert.equal( $( 'ul li:first-child .label', $element ).text(), 'Federal & State Regulation', 'The item has the correct label' );
 
-                assert.equal($('ul li:first-child', $element).data('uri'),  'http://www.my-tao.com#federalStateRegulation', 'The item has the correct URI');
-                assert.equal($('ul li:first-child .label', $element).length, 1, 'The item has a label element');
-                assert.equal($('ul li:first-child .label', $element).text(), 'Federal & State Regulation', 'The item has the correct label');
+                assert.equal( $( 'ul li:first-child .count', $element ).length, 1, 'The item has a count element' );
+                assert.equal( $( 'ul li:first-child .count input', $element ).length, 1, 'The item has an input element' );
+                assert.equal( $( 'ul li:first-child .count input', $element ).val(), '4', 'The item input has the correct value' );
 
-                assert.equal($('ul li:first-child .count', $element).length, 1, 'The item has a count element');
-                assert.equal($('ul li:first-child .count input', $element).length, 1, 'The item has an input element');
-                assert.equal($('ul li:first-child .count input', $element).val(), '4', 'The item input has the correct value');
+                assert.deepEqual( $element[ 0 ], this.getElement()[ 0 ], 'The element is the one bound to the component' );
 
-                assert.deepEqual($element[0], this.getElement()[0], 'The element is the one bound to the component');
+                ready();
+            } );
+    } );
 
-                QUnit.start();
-            });
-    });
+    QUnit.test( 'mounting lifecycle', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-    QUnit.asyncTest('mounting lifecycle', function(assert) {
-        var $container = $('#qunit-fixture');
+        assert.expect( 4 );
 
-        QUnit.expect(4);
+        distributorComponent( $container, { data: samples } )
+            .on( 'init', function() {
+                assert.ok( !this.is( 'rendered' ), 'The component is not yet rendered' );
+                assert.equal( $( '.distributor', $container ).length, 0, 'The component is not yet appended' );
+            } )
+            .on( 'render', function() {
 
-        distributorComponent( $container, { data : samples } )
-            .on('init', function(){
-                assert.ok( ! this.is('rendered'), 'The component is not yet rendered');
-                assert.equal($('.distributor', $container).length, 0, 'The component is not yet appended');
-            })
-            .on('render', function(){
-
-                assert.ok(this.is('rendered'), 'The component is rendered');
-                assert.equal($('.distributor', $container).length, 1, 'The component is  appended');
+                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
+                assert.equal( $( '.distributor', $container ).length, 1, 'The component is  appended' );
 
                 this.destroy();
-            })
-            .on('destroy', function(){
-                QUnit.start();
-            });
-    });
+            } )
+            .on( 'destroy', function() {
+                ready();
+            } );
+    } );
 
-    QUnit.asyncTest('disabling', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'disabling', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-        QUnit.expect(10);
+        assert.expect( 10 );
 
-        distributorComponent( $container, { data : samples } )
-            .on('render', function(){
+        distributorComponent( $container, { data: samples } )
+            .on( 'render', function() {
                 var $element = this.getElement();
-                var $input   = $('li [data-increment]:last-child', $element);
+                var $input   = $( 'li [data-increment]:last-child', $element );
 
-                assert.ok(this.is('rendered'), 'The component is rendered');
-                assert.ok( ! this.is('disabled'), 'The component starts enabled');
-                assert.ok( ! $element.hasClass('disabled'), 'The component starts enabled');
-                assert.ok( ! $input.hasClass('disabled'), 'The input starts enabled');
+                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
+                assert.ok( !this.is( 'disabled' ), 'The component starts enabled' );
+                assert.ok( !$element.hasClass( 'disabled' ), 'The component starts enabled' );
+                assert.ok( !$input.hasClass( 'disabled' ), 'The input starts enabled' );
 
                 this.disable();
-            })
-            .on('disable', function(){
+            } )
+            .on( 'disable', function() {
                 var self     = this;
                 var $element = this.getElement();
-                var $input   = $('li [data-increment]:last-child', $element);
+                var $input   = $( 'li [data-increment]:last-child', $element );
 
-                //push the check after the other handlers exec
-                setTimeout(function(){
-                    assert.ok(self.is('disabled'), 'The component is now disabled');
-                    assert.ok($element.hasClass('disabled'), 'The component is now disabled');
-                    assert.ok( ! $input.hasClass('disabled'), 'The input is now disabled');
+                //Push the check after the other handlers exec
+                setTimeout( function() {
+                    assert.ok( self.is( 'disabled' ), 'The component is now disabled' );
+                    assert.ok( $element.hasClass( 'disabled' ), 'The component is now disabled' );
+                    assert.ok( !$input.hasClass( 'disabled' ), 'The input is now disabled' );
 
                     self.enable();
-                }, 1);
-            })
-            .after('enable', function(){
+                }, 1 );
+            } )
+            .after( 'enable', function() {
                 var self     = this;
                 var $element = this.getElement();
-                var $input   = $('li [data-increment]:last-child', $element);
+                var $input   = $( 'li [data-increment]:last-child', $element );
 
-                //push the check after the other handlers exec
-                setTimeout(function(){
-                    assert.ok( ! self.is('disabled'), 'The component is now enabled');
-                    assert.ok( ! $element.hasClass('disabled'), 'The component is now enabled');
-                    assert.ok( ! $input.hasClass('disabled'), 'The input is now enabled');
+                //Push the check after the other handlers exec
+                setTimeout( function() {
+                    assert.ok( !self.is( 'disabled' ), 'The component is now enabled' );
+                    assert.ok( !$element.hasClass( 'disabled' ), 'The component is now enabled' );
+                    assert.ok( !$input.hasClass( 'disabled' ), 'The input is now enabled' );
 
-                    QUnit.start();
-                }, 1);
-            });
-    });
+                    ready();
+                }, 1 );
+            } );
+    } );
 
-    QUnit.asyncTest('change values', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'change values', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
         var uri = 'http://www.my-tao.com#principlesOfCraningOperations';
 
-        QUnit.expect(11);
+        assert.expect( 11 );
 
-        distributorComponent( $container, { data : samples } )
-            .on('render', function(){
+        distributorComponent( $container, { data: samples } )
+            .on( 'render', function() {
                 var $element = this.getElement();
-                var $item    = $('ul li:nth-child(2)', $element);
-                var $input   = $('[data-increment]', $item);
+                var $item    = $( 'ul li:nth-child(2)', $element );
+                var $input   = $( '[data-increment]', $item );
                 var values   = this.getValues();
 
-                assert.ok(this.is('rendered'), 'The component is rendered');
-                assert.equal($item.length, 1, 'The item exists');
-                assert.equal($item.data('uri'), uri, 'The item URI is correct');
-                assert.equal($input.length, 1, 'The input exists');
+                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
+                assert.equal( $item.length, 1, 'The item exists' );
+                assert.equal( $item.data( 'uri' ), uri, 'The item URI is correct' );
+                assert.equal( $input.length, 1, 'The input exists' );
 
-                assert.equal($input.val(), '5', 'The input has the correct value');
+                assert.equal( $input.val(), '5', 'The input has the correct value' );
 
-                assert.equal(typeof values[uri], 'object', 'The values entry exists');
-                assert.equal(values[uri].value, '5', 'The values matches');
+                assert.equal( typeof values[ uri ], 'object', 'The values entry exists' );
+                assert.equal( values[ uri ].value, '5', 'The values matches' );
 
-                $input.val('7').trigger('change');
-            })
-            .on('change', function(values){
+                $input.val( '7' ).trigger( 'change' );
+            } )
+            .on( 'change', function( values ) {
                 var $element = this.getElement();
-                var $item    = $('ul li:nth-child(2)', $element);
-                var $input   = $('[data-increment]', $item);
+                var $item    = $( 'ul li:nth-child(2)', $element );
+                var $input   = $( '[data-increment]', $item );
 
-                assert.equal($input.val(), '7', 'The input has changed value');
-                assert.deepEqual(values, this.getValues(), 'The values given in parameter matches the component values');
+                assert.equal( $input.val(), '7', 'The input has changed value' );
+                assert.deepEqual( values, this.getValues(), 'The values given in parameter matches the component values' );
 
-                assert.equal(typeof values[uri], 'object', 'The values entry exists');
-                assert.equal(values[uri].value, '7', 'The values matches');
+                assert.equal( typeof values[ uri ], 'object', 'The values entry exists' );
+                assert.equal( values[ uri ].value, '7', 'The values matches' );
 
-                QUnit.start();
-            });
-    });
+                ready();
+            } );
+    } );
 
-    QUnit.asyncTest('no property', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'no property', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-        QUnit.expect(2);
+        assert.expect( 2 );
 
-        distributorComponent( $container, { data : { property : false }} )
-            .on('render', function(){
+        distributorComponent( $container, { data: { property: false } } )
+            .on( 'render', function() {
                 var $element = this.getElement();
-                var $content = $('ul li', $element);
+                var $content = $( 'ul li', $element );
 
-                assert.equal($content.length, 1, 'Only one element is there');
-                assert.equal($content.text().trim(), 'No property defined, please select a property.', 'The message is correct');
+                assert.equal( $content.length, 1, 'Only one element is there' );
+                assert.equal( $content.text().trim(), 'No property defined, please select a property.', 'The message is correct' );
 
-                QUnit.start();
-            });
-    });
+                ready();
+            } );
+    } );
 
-    QUnit.asyncTest('no values', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'no values', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-        QUnit.expect(2);
+        assert.expect( 2 );
 
-        distributorComponent( $container, { data : emptySamples } )
-            .on('render', function(){
+        distributorComponent( $container, { data: emptySamples } )
+            .on( 'render', function() {
                 var $element = this.getElement();
-                var $content = $('ul li', $element);
+                var $content = $( 'ul li', $element );
 
-                assert.equal($content.length, 1, 'Only one element is there');
-                assert.equal($content.text().trim(), 'Topic Area has no resources.', 'The message is correct');
+                assert.equal( $content.length, 1, 'Only one element is there' );
+                assert.equal( $content.text().trim(), 'Topic Area has no resources.', 'The message is correct' );
 
-                QUnit.start();
-            });
-    });
+                ready();
+            } );
+    } );
 
-    QUnit.module('Visual');
+    QUnit.module( 'Visual' );
 
-    QUnit.asyncTest('playground', function(assert) {
-        var container = document.getElementById('visual');
+    QUnit.test( 'playground', function( assert ) {
+        var ready = assert.async();
+        var container = document.getElementById( 'visual' );
 
-        QUnit.expect(1);
+        assert.expect( 1 );
 
-        distributorComponent( container, { data : samples })
-            .on('render', function(){
-                assert.ok(true);
-                QUnit.start();
-            });
-    });
-});
+        distributorComponent( container, { data: samples } )
+            .on( 'render', function() {
+                assert.ok( true );
+                ready();
+            } );
+    } );
+} );

--- a/views/js/test/component/editor/distributor/test.js
+++ b/views/js/test/component/editor/distributor/test.js
@@ -21,256 +21,256 @@
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-define( [
-    
+define([
+
     'jquery',
     'taoBlueprints/component/editor/distributor/distributor',
     'json!taoBlueprints/test/component/editor/distributor/data.json',
     'json!taoBlueprints/test/component/editor/distributor/empty.json'
-], function(  $, distributorComponent, samples, emptySamples ) {
+], function($, distributorComponent, samples, emptySamples) {
     'use strict';
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.expect( 3 );
+    QUnit.test('module', function(assert) {
+        assert.expect(3);
 
-        assert.equal( typeof distributorComponent, 'function', 'The distributorComponent module exposes a function' );
-        assert.equal( typeof distributorComponent(), 'object', 'The distributorComponent factory produces an object' );
-        assert.notStrictEqual( distributorComponent(), distributorComponent(), 'The distributorComponent factory provides a different object on each call' );
-    } );
+        assert.equal(typeof distributorComponent, 'function', 'The distributorComponent module exposes a function');
+        assert.equal(typeof distributorComponent(), 'object', 'The distributorComponent factory produces an object');
+        assert.notStrictEqual(distributorComponent(), distributorComponent(), 'The distributorComponent factory provides a different object on each call');
+    });
 
-    QUnit.cases.init( [
-        { name: 'init',         title: 'init' },
-        { name: 'destroy',      title: 'destroy' },
-        { name: 'render',       title: 'render' },
-        { name: 'show',         title: 'show' },
-        { name: 'hide',         title: 'hide' },
-        { name: 'enable',       title: 'enable' },
-        { name: 'disable',      title: 'disable' },
-        { name: 'is',           title: 'is' },
-        { name: 'setState',     title: 'setState' },
-        { name: 'getContainer', title: 'getContainer' },
-        { name: 'getElement',   title: 'getElement' },
-        { name: 'getTemplate',  title: 'getTemplate' },
-        { name: 'setTemplate',  title: 'setTemplate' }
-    ] )
-    .test( 'component ', function( data, assert ) {
+    QUnit.cases.init([
+        {name: 'init', title: 'init'},
+        {name: 'destroy', title: 'destroy'},
+        {name: 'render', title: 'render'},
+        {name: 'show', title: 'show'},
+        {name: 'hide', title: 'hide'},
+        {name: 'enable', title: 'enable'},
+        {name: 'disable', title: 'disable'},
+        {name: 'is', title: 'is'},
+        {name: 'setState', title: 'setState'},
+        {name: 'getContainer', title: 'getContainer'},
+        {name: 'getElement', title: 'getElement'},
+        {name: 'getTemplate', title: 'getTemplate'},
+        {name: 'setTemplate', title: 'setTemplate'}
+    ])
+    .test('component ', function(data, assert) {
         var instance = distributorComponent();
-        assert.equal( typeof instance[ data.name ], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function' );
-    } );
+        assert.equal(typeof instance[data.name], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function');
+    });
 
-    QUnit.cases.init( [
-        { name: 'on',      title: 'on' },
-        { name: 'off',     title: 'off' },
-        { name: 'trigger', title: 'trigger' }
-    ] )
-    .test( 'eventifier ', function( data, assert ) {
+    QUnit.cases.init([
+        {name: 'on', title: 'on'},
+        {name: 'off', title: 'off'},
+        {name: 'trigger', title: 'trigger'}
+    ])
+    .test('eventifier ', function(data, assert) {
         var instance = distributorComponent();
-        assert.equal( typeof instance[ data.name ], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function' );
-    } );
+        assert.equal(typeof instance[data.name], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function');
+    });
 
-    QUnit.cases.init( [
-        { name: 'getValues', title: 'getValues' }
-    ] )
-    .test( 'spec ', function( data, assert ) {
+    QUnit.cases.init([
+        {name: 'getValues', title: 'getValues'}
+    ])
+    .test('spec ', function(data, assert) {
         var instance = distributorComponent();
-        assert.equal( typeof instance[ data.name ], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function' );
-    } );
+        assert.equal(typeof instance[data.name], 'function', 'The distributorComponent instance exposes a "' + data.title + '" function');
+    });
 
-    QUnit.module( 'Behavior' );
+    QUnit.module('Behavior');
 
-    QUnit.test( 'DOM rendering', function( assert ) {
+    QUnit.test('DOM rendering', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 12 );
+        assert.expect(12);
 
-        distributorComponent( $container, { data: samples } )
-            .on( 'render', function() {
-                var $element = $( '.distributor', $container );
+        distributorComponent($container, {data: samples})
+            .on('render', function() {
+                var $element = $('.distributor', $container);
 
-                assert.equal( $element.length, 1, 'The container has the component root element' );
-                assert.ok( $element.hasClass( 'rendered' ), 1, 'The component root element has the rendered class' );
+                assert.equal($element.length, 1, 'The container has the component root element');
+                assert.ok($element.hasClass('rendered'), 1, 'The component root element has the rendered class');
 
-                assert.equal( $( 'header', $element ).length, 1, 'The component has an header element' );
-                assert.equal( $( 'ul', $element ).length, 1, 'The component has an list element' );
-                assert.equal( $( 'ul li', $element ).length, 5, 'The component has the correct number of items' );
+                assert.equal($('header', $element).length, 1, 'The component has an header element');
+                assert.equal($('ul', $element).length, 1, 'The component has an list element');
+                assert.equal($('ul li', $element).length, 5, 'The component has the correct number of items');
 
-                assert.equal( $( 'ul li:first-child', $element ).data( 'uri' ),  'http://www.my-tao.com#federalStateRegulation', 'The item has the correct URI' );
-                assert.equal( $( 'ul li:first-child .label', $element ).length, 1, 'The item has a label element' );
-                assert.equal( $( 'ul li:first-child .label', $element ).text(), 'Federal & State Regulation', 'The item has the correct label' );
+                assert.equal($('ul li:first-child', $element).data('uri'), 'http://www.my-tao.com#federalStateRegulation', 'The item has the correct URI');
+                assert.equal($('ul li:first-child .label', $element).length, 1, 'The item has a label element');
+                assert.equal($('ul li:first-child .label', $element).text(), 'Federal & State Regulation', 'The item has the correct label');
 
-                assert.equal( $( 'ul li:first-child .count', $element ).length, 1, 'The item has a count element' );
-                assert.equal( $( 'ul li:first-child .count input', $element ).length, 1, 'The item has an input element' );
-                assert.equal( $( 'ul li:first-child .count input', $element ).val(), '4', 'The item input has the correct value' );
+                assert.equal($('ul li:first-child .count', $element).length, 1, 'The item has a count element');
+                assert.equal($('ul li:first-child .count input', $element).length, 1, 'The item has an input element');
+                assert.equal($('ul li:first-child .count input', $element).val(), '4', 'The item input has the correct value');
 
-                assert.deepEqual( $element[ 0 ], this.getElement()[ 0 ], 'The element is the one bound to the component' );
+                assert.deepEqual($element[0], this.getElement()[0], 'The element is the one bound to the component');
 
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.test( 'mounting lifecycle', function( assert ) {
+    QUnit.test('mounting lifecycle', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 4 );
+        assert.expect(4);
 
-        distributorComponent( $container, { data: samples } )
-            .on( 'init', function() {
-                assert.ok( !this.is( 'rendered' ), 'The component is not yet rendered' );
-                assert.equal( $( '.distributor', $container ).length, 0, 'The component is not yet appended' );
-            } )
-            .on( 'render', function() {
+        distributorComponent($container, {data: samples})
+            .on('init', function() {
+                assert.ok(!this.is('rendered'), 'The component is not yet rendered');
+                assert.equal($('.distributor', $container).length, 0, 'The component is not yet appended');
+            })
+            .on('render', function() {
 
-                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
-                assert.equal( $( '.distributor', $container ).length, 1, 'The component is  appended' );
+                assert.ok(this.is('rendered'), 'The component is rendered');
+                assert.equal($('.distributor', $container).length, 1, 'The component is  appended');
 
                 this.destroy();
-            } )
-            .on( 'destroy', function() {
+            })
+            .on('destroy', function() {
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.test( 'disabling', function( assert ) {
+    QUnit.test('disabling', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 10 );
+        assert.expect(10);
 
-        distributorComponent( $container, { data: samples } )
-            .on( 'render', function() {
+        distributorComponent($container, {data: samples})
+            .on('render', function() {
                 var $element = this.getElement();
-                var $input   = $( 'li [data-increment]:last-child', $element );
+                var $input = $('li [data-increment]:last-child', $element);
 
-                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
-                assert.ok( !this.is( 'disabled' ), 'The component starts enabled' );
-                assert.ok( !$element.hasClass( 'disabled' ), 'The component starts enabled' );
-                assert.ok( !$input.hasClass( 'disabled' ), 'The input starts enabled' );
+                assert.ok(this.is('rendered'), 'The component is rendered');
+                assert.ok(!this.is('disabled'), 'The component starts enabled');
+                assert.ok(!$element.hasClass('disabled'), 'The component starts enabled');
+                assert.ok(!$input.hasClass('disabled'), 'The input starts enabled');
 
                 this.disable();
-            } )
-            .on( 'disable', function() {
-                var self     = this;
+            })
+            .on('disable', function() {
+                var self = this;
                 var $element = this.getElement();
-                var $input   = $( 'li [data-increment]:last-child', $element );
+                var $input = $('li [data-increment]:last-child', $element);
 
                 //Push the check after the other handlers exec
-                setTimeout( function() {
-                    assert.ok( self.is( 'disabled' ), 'The component is now disabled' );
-                    assert.ok( $element.hasClass( 'disabled' ), 'The component is now disabled' );
-                    assert.ok( !$input.hasClass( 'disabled' ), 'The input is now disabled' );
+                setTimeout(function() {
+                    assert.ok(self.is('disabled'), 'The component is now disabled');
+                    assert.ok($element.hasClass('disabled'), 'The component is now disabled');
+                    assert.ok(!$input.hasClass('disabled'), 'The input is now disabled');
 
                     self.enable();
-                }, 1 );
-            } )
-            .after( 'enable', function() {
-                var self     = this;
+                }, 1);
+            })
+            .after('enable', function() {
+                var self = this;
                 var $element = this.getElement();
-                var $input   = $( 'li [data-increment]:last-child', $element );
+                var $input = $('li [data-increment]:last-child', $element);
 
                 //Push the check after the other handlers exec
-                setTimeout( function() {
-                    assert.ok( !self.is( 'disabled' ), 'The component is now enabled' );
-                    assert.ok( !$element.hasClass( 'disabled' ), 'The component is now enabled' );
-                    assert.ok( !$input.hasClass( 'disabled' ), 'The input is now enabled' );
+                setTimeout(function() {
+                    assert.ok(!self.is('disabled'), 'The component is now enabled');
+                    assert.ok(!$element.hasClass('disabled'), 'The component is now enabled');
+                    assert.ok(!$input.hasClass('disabled'), 'The input is now enabled');
 
                     ready();
-                }, 1 );
-            } );
-    } );
+                }, 1);
+            });
+    });
 
-    QUnit.test( 'change values', function( assert ) {
+    QUnit.test('change values', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
         var uri = 'http://www.my-tao.com#principlesOfCraningOperations';
 
-        assert.expect( 11 );
+        assert.expect(11);
 
-        distributorComponent( $container, { data: samples } )
-            .on( 'render', function() {
+        distributorComponent($container, {data: samples})
+            .on('render', function() {
                 var $element = this.getElement();
-                var $item    = $( 'ul li:nth-child(2)', $element );
-                var $input   = $( '[data-increment]', $item );
-                var values   = this.getValues();
+                var $item = $('ul li:nth-child(2)', $element);
+                var $input = $('[data-increment]', $item);
+                var values = this.getValues();
 
-                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
-                assert.equal( $item.length, 1, 'The item exists' );
-                assert.equal( $item.data( 'uri' ), uri, 'The item URI is correct' );
-                assert.equal( $input.length, 1, 'The input exists' );
+                assert.ok(this.is('rendered'), 'The component is rendered');
+                assert.equal($item.length, 1, 'The item exists');
+                assert.equal($item.data('uri'), uri, 'The item URI is correct');
+                assert.equal($input.length, 1, 'The input exists');
 
-                assert.equal( $input.val(), '5', 'The input has the correct value' );
+                assert.equal($input.val(), '5', 'The input has the correct value');
 
-                assert.equal( typeof values[ uri ], 'object', 'The values entry exists' );
-                assert.equal( values[ uri ].value, '5', 'The values matches' );
+                assert.equal(typeof values[uri], 'object', 'The values entry exists');
+                assert.equal(values[uri].value, '5', 'The values matches');
 
-                $input.val( '7' ).trigger( 'change' );
-            } )
-            .on( 'change', function( values ) {
+                $input.val('7').trigger('change');
+            })
+            .on('change', function(values) {
                 var $element = this.getElement();
-                var $item    = $( 'ul li:nth-child(2)', $element );
-                var $input   = $( '[data-increment]', $item );
+                var $item = $('ul li:nth-child(2)', $element);
+                var $input = $('[data-increment]', $item);
 
-                assert.equal( $input.val(), '7', 'The input has changed value' );
-                assert.deepEqual( values, this.getValues(), 'The values given in parameter matches the component values' );
+                assert.equal($input.val(), '7', 'The input has changed value');
+                assert.deepEqual(values, this.getValues(), 'The values given in parameter matches the component values');
 
-                assert.equal( typeof values[ uri ], 'object', 'The values entry exists' );
-                assert.equal( values[ uri ].value, '7', 'The values matches' );
+                assert.equal(typeof values[uri], 'object', 'The values entry exists');
+                assert.equal(values[uri].value, '7', 'The values matches');
 
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.test( 'no property', function( assert ) {
+    QUnit.test('no property', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 2 );
+        assert.expect(2);
 
-        distributorComponent( $container, { data: { property: false } } )
-            .on( 'render', function() {
+        distributorComponent($container, {data: {property: false}})
+            .on('render', function() {
                 var $element = this.getElement();
-                var $content = $( 'ul li', $element );
+                var $content = $('ul li', $element);
 
-                assert.equal( $content.length, 1, 'Only one element is there' );
-                assert.equal( $content.text().trim(), 'No property defined, please select a property.', 'The message is correct' );
+                assert.equal($content.length, 1, 'Only one element is there');
+                assert.equal($content.text().trim(), 'No property defined, please select a property.', 'The message is correct');
 
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.test( 'no values', function( assert ) {
+    QUnit.test('no values', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 2 );
+        assert.expect(2);
 
-        distributorComponent( $container, { data: emptySamples } )
-            .on( 'render', function() {
+        distributorComponent($container, {data: emptySamples})
+            .on('render', function() {
                 var $element = this.getElement();
-                var $content = $( 'ul li', $element );
+                var $content = $('ul li', $element);
 
-                assert.equal( $content.length, 1, 'Only one element is there' );
-                assert.equal( $content.text().trim(), 'Topic Area has no resources.', 'The message is correct' );
+                assert.equal($content.length, 1, 'Only one element is there');
+                assert.equal($content.text().trim(), 'Topic Area has no resources.', 'The message is correct');
 
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.module( 'Visual' );
+    QUnit.module('Visual');
 
-    QUnit.test( 'playground', function( assert ) {
+    QUnit.test('playground', function(assert) {
         var ready = assert.async();
-        var container = document.getElementById( 'visual' );
+        var container = document.getElementById('visual');
 
-        assert.expect( 1 );
+        assert.expect(1);
 
-        distributorComponent( container, { data: samples } )
-            .on( 'render', function() {
-                assert.ok( true );
+        distributorComponent(container, {data: samples})
+            .on('render', function() {
+                assert.ok(true);
                 ready();
-            } );
-    } );
-} );
+            });
+    });
+});

--- a/views/js/test/component/editor/editor/test.html
+++ b/views/js/test/component/editor/editor/test.html
@@ -6,8 +6,8 @@
         <base href="../../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="editor/editor.js"></script>
 

--- a/views/js/test/component/editor/editor/test.js
+++ b/views/js/test/component/editor/editor/test.js
@@ -17,225 +17,229 @@
  */
 
 /**
- * Test the Blueprint Editor's editor component
+ * Test the Blueprint Edito\'s editor component
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-define([
+define( [
+    
     'jquery',
     'taoBlueprints/component/editor/editor',
     'json!taoBlueprints/test/component/editor/editor/data.json',
-    'json!taoBlueprints/test/component/editor/editor/selection.json',
-], function($, editorComponent, samples, selection) {
+    'json!taoBlueprints/test/component/editor/editor/selection.json'
+], function(  $, editorComponent, samples, selection ) {
     'use strict';
 
     var config = {
-        data : samples
+        data: samples
     };
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('module', function(assert) {
-        QUnit.expect(3);
+    QUnit.test( 'module', function( assert ) {
+        assert.expect( 3 );
 
-        assert.equal(typeof editorComponent, 'function', "The editorComponent module exposes a function");
-        assert.equal(typeof editorComponent(null, config), 'object', "The editorComponent factory produces an object");
-        assert.notStrictEqual(editorComponent(null, config), editorComponent(null, config), "The editorComponent factory provides a different object on each call");
-    });
+        assert.equal( typeof editorComponent, 'function', 'The editorComponent module exposes a function' );
+        assert.equal( typeof editorComponent( null, config ), 'object', 'The editorComponent factory produces an object' );
+        assert.notStrictEqual( editorComponent( null, config ), editorComponent( null, config ), 'The editorComponent factory provides a different object on each call' );
+    } );
 
-    QUnit.cases([
-        { name : 'init',         title : 'init' },
-        { name : 'destroy',      title : 'destroy' },
-        { name : 'render',       title : 'render' },
-        { name : 'show',         title : 'show' },
-        { name : 'hide',         title : 'hide' },
-        { name : 'enable',       title : 'enable' },
-        { name : 'disable',      title : 'disable' },
-        { name : 'is',           title : 'is' },
-        { name : 'setState',     title : 'setState' },
-        { name : 'getContainer', title : 'getContainer' },
-        { name : 'getElement',   title : 'getElement' },
-        { name : 'getTemplate',  title : 'getTemplate' },
-        { name : 'setTemplate',  title : 'setTemplate' }
-    ])
-    .test('component ', function(data, assert) {
-        var instance = editorComponent(null, config);
-        assert.equal(typeof instance[data.name], 'function', 'The editorComponent instance exposes a "' + data.title + '" function');
-    });
+    QUnit.cases.init( [
+        { name: 'init',         title: 'init' },
+        { name: 'destroy',      title: 'destroy' },
+        { name: 'render',       title: 'render' },
+        { name: 'show',         title: 'show' },
+        { name: 'hide',         title: 'hide' },
+        { name: 'enable',       title: 'enable' },
+        { name: 'disable',      title: 'disable' },
+        { name: 'is',           title: 'is' },
+        { name: 'setState',     title: 'setState' },
+        { name: 'getContainer', title: 'getContainer' },
+        { name: 'getElement',   title: 'getElement' },
+        { name: 'getTemplate',  title: 'getTemplate' },
+        { name: 'setTemplate',  title: 'setTemplate' }
+    ] )
+    .test( 'component ', function( data, assert ) {
+        var instance = editorComponent( null, config );
+        assert.equal( typeof instance[ data.name ], 'function', 'The editorComponent instance exposes a "' + data.title + '" function' );
+    } );
 
-    QUnit.cases([
-        { name : 'on',      title : 'on' },
-        { name : 'off',     title : 'off' },
-        { name : 'trigger', title : 'trigger' }
-    ])
-    .test('eventifier ', function(data, assert) {
-        var instance = editorComponent(null, config);
-        assert.equal(typeof instance[data.name], 'function', 'The editorComponent instance exposes a "' + data.title + '" function');
-    });
+    QUnit.cases.init( [
+        { name: 'on',      title: 'on' },
+        { name: 'off',     title: 'off' },
+        { name: 'trigger', title: 'trigger' }
+    ] )
+    .test( 'eventifier ', function( data, assert ) {
+        var instance = editorComponent( null, config );
+        assert.equal( typeof instance[ data.name ], 'function', 'The editorComponent instance exposes a "' + data.title + '" function' );
+    } );
 
-    QUnit.cases([
-        { name : 'refresh',   title : 'refresh' },
-        { name : 'getValues', title : 'getValues' }
-    ])
-    .test('spec ', function(data, assert) {
-        var instance = editorComponent(null, config);
-        assert.equal(typeof instance[data.name], 'function', 'The editorComponent instance exposes a "' + data.title + '" function');
-    });
+    QUnit.cases.init( [
+        { name: 'refresh',   title: 'refresh' },
+        { name: 'getValues', title: 'getValues' }
+    ] )
+    .test( 'spec ', function( data, assert ) {
+        var instance = editorComponent( null, config );
+        assert.equal( typeof instance[ data.name ], 'function', 'The editorComponent instance exposes a "' + data.title + '" function' );
+    } );
 
+    QUnit.module( 'Behavior' );
 
-    QUnit.module('Behavior');
+    QUnit.test( 'DOM rendering', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-    QUnit.asyncTest('DOM rendering', function(assert) {
-        var $container = $('#qunit-fixture');
-
-        QUnit.expect(7);
-
-        editorComponent( $container, config )
-            .on('render', function(){
-                var $element = $('.blueprint-editor', $container);
-
-                assert.equal($element.length, 1, 'The container has the component root element');
-                assert.ok($element.hasClass('rendered'), 1, 'The component root element has the rendered class');
-
-                assert.equal($('.property-selector-container', $element).length, 1, 'The component has property selector container element');
-                assert.equal($('.distributor-container', $element).length, 1, 'The component has the distributor container element');
-                assert.equal($('.controls', $element).length, 1, 'The component has the controls container element');
-                assert.equal($('.controls .saver', $element).length, 1, 'The component has the saver element');
-
-                assert.deepEqual($element[0], this.getElement()[0], 'The element is the one bound to the component');
-
-                QUnit.start();
-            });
-    });
-
-    QUnit.asyncTest('mounting lifecycle', function(assert) {
-        var $container = $('#qunit-fixture');
-
-        QUnit.expect(4);
+        assert.expect( 7 );
 
         editorComponent( $container, config )
-            .on('init', function(){
-                assert.ok( ! this.is('rendered'), 'The component is not yet rendered');
-                assert.equal($('.blueprint-editor', $container).length, 0, 'The component is not yet appended');
-            })
-            .on('render', function(){
+            .on( 'render', function() {
+                var $element = $( '.blueprint-editor', $container );
 
-                assert.ok(this.is('rendered'), 'The component is rendered');
-                assert.equal($('.blueprint-editor', $container).length, 1, 'The component is  appended');
+                assert.equal( $element.length, 1, 'The container has the component root element' );
+                assert.ok( $element.hasClass( 'rendered' ), 1, 'The component root element has the rendered class' );
+
+                assert.equal( $( '.property-selector-container', $element ).length, 1, 'The component has property selector container element' );
+                assert.equal( $( '.distributor-container', $element ).length, 1, 'The component has the distributor container element' );
+                assert.equal( $( '.controls', $element ).length, 1, 'The component has the controls container element' );
+                assert.equal( $( '.controls .saver', $element ).length, 1, 'The component has the saver element' );
+
+                assert.deepEqual( $element[ 0 ], this.getElement()[ 0 ], 'The element is the one bound to the component' );
+
+                ready();
+            } );
+    } );
+
+    QUnit.test( 'mounting lifecycle', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
+
+        assert.expect( 4 );
+
+        editorComponent( $container, config )
+            .on( 'init', function() {
+                assert.ok( !this.is( 'rendered' ), 'The component is not yet rendered' );
+                assert.equal( $( '.blueprint-editor', $container ).length, 0, 'The component is not yet appended' );
+            } )
+            .on( 'render', function() {
+
+                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
+                assert.equal( $( '.blueprint-editor', $container ).length, 1, 'The component is  appended' );
 
                 this.destroy();
-            })
-            .on('destroy', function(){
-                QUnit.start();
-            });
-    });
+            } )
+            .on( 'destroy', function() {
+                ready();
+            } );
+    } );
 
-    QUnit.asyncTest('disabling', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'disabling', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-        QUnit.expect(7);
+        assert.expect( 7 );
 
         editorComponent( $container, config )
-            .on('render', function(){
+            .on( 'render', function() {
                 var $element = this.getElement();
 
-                assert.ok(this.is('rendered'), 'The component is rendered');
-                assert.ok( ! this.is('disabled'), 'The component starts enabled');
-                assert.ok( ! $element.hasClass('disabled'), 'The component starts enabled');
+                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
+                assert.ok( !this.is( 'disabled' ), 'The component starts enabled' );
+                assert.ok( !$element.hasClass( 'disabled' ), 'The component starts enabled' );
 
                 this.disable();
-            })
-            .on('disable', function(){
+            } )
+            .on( 'disable', function() {
                 var self     = this;
                 var $element = this.getElement();
 
-                //push the check after the other handlers exec
-                setTimeout(function(){
-                    assert.ok(self.is('disabled'), 'The component is now disabled');
-                    assert.ok($element.hasClass('disabled'), 'The component is now disabled');
+                //Push the check after the other handlers exec
+                setTimeout( function() {
+                    assert.ok( self.is( 'disabled' ), 'The component is now disabled' );
+                    assert.ok( $element.hasClass( 'disabled' ), 'The component is now disabled' );
 
                     self.enable();
-                }, 1);
-            })
-            .after('enable', function(){
+                }, 1 );
+            } )
+            .after( 'enable', function() {
                 var self     = this;
                 var $element = this.getElement();
 
-                //push the check after the other handlers exec
-                setTimeout(function(){
-                    assert.ok( ! self.is('disabled'), 'The component is now enabled');
-                    assert.ok( ! $element.hasClass('disabled'), 'The component is now enabled');
-                    QUnit.start();
-                }, 1);
-            });
-    });
+                //Push the check after the other handlers exec
+                setTimeout( function() {
+                    assert.ok( !self.is( 'disabled' ), 'The component is now enabled' );
+                    assert.ok( !$element.hasClass( 'disabled' ), 'The component is now enabled' );
+                    ready();
+                }, 1 );
+            } );
+    } );
 
-    QUnit.asyncTest('change values', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'change values', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-        QUnit.expect(9);
+        assert.expect( 9 );
 
         editorComponent( $container, config )
-            .on('render', function(){
+            .on( 'render', function() {
                 var self = this;
-                setTimeout(function(){
+                setTimeout( function() {
                     var $element  = self.getElement();
-                    var $selector = $('.property-selector', $element);
+                    var $selector = $( '.property-selector', $element );
                     var values    = self.getValues();
 
-                    assert.ok(self.is('rendered'), 'The component is rendered');
-                    assert.equal($selector.length, 1, 'The selecor exists');
+                    assert.ok( self.is( 'rendered' ), 'The component is rendered' );
+                    assert.equal( $selector.length, 1, 'The selecor exists' );
 
-                    assert.deepEqual(values.property, samples.property, 'The property value matches the default config');
-                    assert.deepEqual(values.selection, samples.selection, 'The selection value matches the default config');
+                    assert.deepEqual( values.property, samples.property, 'The property value matches the default config' );
+                    assert.deepEqual( values.selection, samples.selection, 'The selection value matches the default config' );
 
-                    $('.selected', $selector).click();
+                    $( '.selected', $selector ).click();
 
-                    setTimeout(function(){
-                        $('.options li:first-child a', $selector).click();
-                    }, 500);
-                }, 50);
-            })
-            .on('propertyChange', function(uri, label){
-                assert.equal(uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct');
-                assert.equal(label, 'Identifier', 'The selected label is correct');
+                    setTimeout( function() {
+                        $( '.options li:first-child a', $selector ).click();
+                    }, 500 );
+                }, 50 );
+            } )
+            .on( 'propertyChange', function( uri, label ) {
+                assert.equal( uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct' );
+                assert.equal( label, 'Identifier', 'The selected label is correct' );
 
-                this.refresh(uri, label, selection);
-            })
-            .on('refresh', function(){
+                this.refresh( uri, label, selection );
+            } )
+            .on( 'refresh', function() {
                 var values    = this.getValues();
 
-                assert.equal(values.property.uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct');
-                assert.equal(values.property.label, 'Identifier', 'The selected label is correct');
-                assert.deepEqual(values.selection, selection, 'The selection value matches the default config');
+                assert.equal( values.property.uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct' );
+                assert.equal( values.property.label, 'Identifier', 'The selected label is correct' );
+                assert.deepEqual( values.selection, selection, 'The selection value matches the default config' );
 
-                QUnit.start();
-            });
-    });
+                ready();
+            } );
+    } );
 
+    QUnit.module( 'Visual' );
 
-    QUnit.module('Visual');
+    QUnit.test( 'playground', function( assert ) {
+        var ready = assert.async();
+        var container = document.getElementById( 'visual' );
 
-    QUnit.asyncTest('playground', function(assert) {
-        var container = document.getElementById('visual');
+        assert.expect( 1 );
 
-        QUnit.expect(1);
-
-        editorComponent( container, { data : samples })
-            .on('render', function(){
-                assert.ok(true);
-                QUnit.start();
-            })
-            .on('propertyChange', function(uri, label){
+        editorComponent( container, { data: samples } )
+            .on( 'render', function() {
+                assert.ok( true );
+                ready();
+            } )
+            .on( 'propertyChange', function( uri, label ) {
                 var self = this;
                 this.disable();
-                this.off('resfresh')
-                    .on('refresh', function(){
+                this.off( 'resfresh' )
+                    .on( 'refresh', function() {
                         this.enable();
-                    });
-                setTimeout(function(){
-                    self.refresh(uri, label, selection);
-                }, 1500);
-            });
-    });
-});
+                    } );
+                setTimeout( function() {
+                    self.refresh( uri, label, selection );
+                }, 1500 );
+            } );
+    } );
+} );

--- a/views/js/test/component/editor/editor/test.js
+++ b/views/js/test/component/editor/editor/test.js
@@ -21,225 +21,225 @@
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-define( [
-    
+define([
+
     'jquery',
     'taoBlueprints/component/editor/editor',
     'json!taoBlueprints/test/component/editor/editor/data.json',
     'json!taoBlueprints/test/component/editor/editor/selection.json'
-], function(  $, editorComponent, samples, selection ) {
+], function($, editorComponent, samples, selection) {
     'use strict';
 
     var config = {
         data: samples
     };
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.expect( 3 );
+    QUnit.test('module', function(assert) {
+        assert.expect(3);
 
-        assert.equal( typeof editorComponent, 'function', 'The editorComponent module exposes a function' );
-        assert.equal( typeof editorComponent( null, config ), 'object', 'The editorComponent factory produces an object' );
-        assert.notStrictEqual( editorComponent( null, config ), editorComponent( null, config ), 'The editorComponent factory provides a different object on each call' );
-    } );
+        assert.equal(typeof editorComponent, 'function', 'The editorComponent module exposes a function');
+        assert.equal(typeof editorComponent(null, config), 'object', 'The editorComponent factory produces an object');
+        assert.notStrictEqual(editorComponent(null, config), editorComponent(null, config), 'The editorComponent factory provides a different object on each call');
+    });
 
-    QUnit.cases.init( [
-        { name: 'init',         title: 'init' },
-        { name: 'destroy',      title: 'destroy' },
-        { name: 'render',       title: 'render' },
-        { name: 'show',         title: 'show' },
-        { name: 'hide',         title: 'hide' },
-        { name: 'enable',       title: 'enable' },
-        { name: 'disable',      title: 'disable' },
-        { name: 'is',           title: 'is' },
-        { name: 'setState',     title: 'setState' },
-        { name: 'getContainer', title: 'getContainer' },
-        { name: 'getElement',   title: 'getElement' },
-        { name: 'getTemplate',  title: 'getTemplate' },
-        { name: 'setTemplate',  title: 'setTemplate' }
-    ] )
-    .test( 'component ', function( data, assert ) {
-        var instance = editorComponent( null, config );
-        assert.equal( typeof instance[ data.name ], 'function', 'The editorComponent instance exposes a "' + data.title + '" function' );
-    } );
+    QUnit.cases.init([
+        {name: 'init', title: 'init'},
+        {name: 'destroy', title: 'destroy'},
+        {name: 'render', title: 'render'},
+        {name: 'show', title: 'show'},
+        {name: 'hide', title: 'hide'},
+        {name: 'enable', title: 'enable'},
+        {name: 'disable', title: 'disable'},
+        {name: 'is', title: 'is'},
+        {name: 'setState', title: 'setState'},
+        {name: 'getContainer', title: 'getContainer'},
+        {name: 'getElement', title: 'getElement'},
+        {name: 'getTemplate', title: 'getTemplate'},
+        {name: 'setTemplate', title: 'setTemplate'}
+    ])
+    .test('component ', function(data, assert) {
+        var instance = editorComponent(null, config);
+        assert.equal(typeof instance[data.name], 'function', 'The editorComponent instance exposes a "' + data.title + '" function');
+    });
 
-    QUnit.cases.init( [
-        { name: 'on',      title: 'on' },
-        { name: 'off',     title: 'off' },
-        { name: 'trigger', title: 'trigger' }
-    ] )
-    .test( 'eventifier ', function( data, assert ) {
-        var instance = editorComponent( null, config );
-        assert.equal( typeof instance[ data.name ], 'function', 'The editorComponent instance exposes a "' + data.title + '" function' );
-    } );
+    QUnit.cases.init([
+        {name: 'on', title: 'on'},
+        {name: 'off', title: 'off'},
+        {name: 'trigger', title: 'trigger'}
+    ])
+    .test('eventifier ', function(data, assert) {
+        var instance = editorComponent(null, config);
+        assert.equal(typeof instance[data.name], 'function', 'The editorComponent instance exposes a "' + data.title + '" function');
+    });
 
-    QUnit.cases.init( [
-        { name: 'refresh',   title: 'refresh' },
-        { name: 'getValues', title: 'getValues' }
-    ] )
-    .test( 'spec ', function( data, assert ) {
-        var instance = editorComponent( null, config );
-        assert.equal( typeof instance[ data.name ], 'function', 'The editorComponent instance exposes a "' + data.title + '" function' );
-    } );
+    QUnit.cases.init([
+        {name: 'refresh', title: 'refresh'},
+        {name: 'getValues', title: 'getValues'}
+    ])
+    .test('spec ', function(data, assert) {
+        var instance = editorComponent(null, config);
+        assert.equal(typeof instance[data.name], 'function', 'The editorComponent instance exposes a "' + data.title + '" function');
+    });
 
-    QUnit.module( 'Behavior' );
+    QUnit.module('Behavior');
 
-    QUnit.test( 'DOM rendering', function( assert ) {
+    QUnit.test('DOM rendering', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 7 );
+        assert.expect(7);
 
-        editorComponent( $container, config )
-            .on( 'render', function() {
-                var $element = $( '.blueprint-editor', $container );
+        editorComponent($container, config)
+            .on('render', function() {
+                var $element = $('.blueprint-editor', $container);
 
-                assert.equal( $element.length, 1, 'The container has the component root element' );
-                assert.ok( $element.hasClass( 'rendered' ), 1, 'The component root element has the rendered class' );
+                assert.equal($element.length, 1, 'The container has the component root element');
+                assert.ok($element.hasClass('rendered'), 1, 'The component root element has the rendered class');
 
-                assert.equal( $( '.property-selector-container', $element ).length, 1, 'The component has property selector container element' );
-                assert.equal( $( '.distributor-container', $element ).length, 1, 'The component has the distributor container element' );
-                assert.equal( $( '.controls', $element ).length, 1, 'The component has the controls container element' );
-                assert.equal( $( '.controls .saver', $element ).length, 1, 'The component has the saver element' );
+                assert.equal($('.property-selector-container', $element).length, 1, 'The component has property selector container element');
+                assert.equal($('.distributor-container', $element).length, 1, 'The component has the distributor container element');
+                assert.equal($('.controls', $element).length, 1, 'The component has the controls container element');
+                assert.equal($('.controls .saver', $element).length, 1, 'The component has the saver element');
 
-                assert.deepEqual( $element[ 0 ], this.getElement()[ 0 ], 'The element is the one bound to the component' );
+                assert.deepEqual($element[0], this.getElement()[0], 'The element is the one bound to the component');
 
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.test( 'mounting lifecycle', function( assert ) {
+    QUnit.test('mounting lifecycle', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 4 );
+        assert.expect(4);
 
-        editorComponent( $container, config )
-            .on( 'init', function() {
-                assert.ok( !this.is( 'rendered' ), 'The component is not yet rendered' );
-                assert.equal( $( '.blueprint-editor', $container ).length, 0, 'The component is not yet appended' );
-            } )
-            .on( 'render', function() {
+        editorComponent($container, config)
+            .on('init', function() {
+                assert.ok(!this.is('rendered'), 'The component is not yet rendered');
+                assert.equal($('.blueprint-editor', $container).length, 0, 'The component is not yet appended');
+            })
+            .on('render', function() {
 
-                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
-                assert.equal( $( '.blueprint-editor', $container ).length, 1, 'The component is  appended' );
+                assert.ok(this.is('rendered'), 'The component is rendered');
+                assert.equal($('.blueprint-editor', $container).length, 1, 'The component is  appended');
 
                 this.destroy();
-            } )
-            .on( 'destroy', function() {
+            })
+            .on('destroy', function() {
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.test( 'disabling', function( assert ) {
+    QUnit.test('disabling', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 7 );
+        assert.expect(7);
 
-        editorComponent( $container, config )
-            .on( 'render', function() {
+        editorComponent($container, config)
+            .on('render', function() {
                 var $element = this.getElement();
 
-                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
-                assert.ok( !this.is( 'disabled' ), 'The component starts enabled' );
-                assert.ok( !$element.hasClass( 'disabled' ), 'The component starts enabled' );
+                assert.ok(this.is('rendered'), 'The component is rendered');
+                assert.ok(!this.is('disabled'), 'The component starts enabled');
+                assert.ok(!$element.hasClass('disabled'), 'The component starts enabled');
 
                 this.disable();
-            } )
-            .on( 'disable', function() {
-                var self     = this;
+            })
+            .on('disable', function() {
+                var self = this;
                 var $element = this.getElement();
 
                 //Push the check after the other handlers exec
-                setTimeout( function() {
-                    assert.ok( self.is( 'disabled' ), 'The component is now disabled' );
-                    assert.ok( $element.hasClass( 'disabled' ), 'The component is now disabled' );
+                setTimeout(function() {
+                    assert.ok(self.is('disabled'), 'The component is now disabled');
+                    assert.ok($element.hasClass('disabled'), 'The component is now disabled');
 
                     self.enable();
-                }, 1 );
-            } )
-            .after( 'enable', function() {
-                var self     = this;
+                }, 1);
+            })
+            .after('enable', function() {
+                var self = this;
                 var $element = this.getElement();
 
                 //Push the check after the other handlers exec
-                setTimeout( function() {
-                    assert.ok( !self.is( 'disabled' ), 'The component is now enabled' );
-                    assert.ok( !$element.hasClass( 'disabled' ), 'The component is now enabled' );
+                setTimeout(function() {
+                    assert.ok(!self.is('disabled'), 'The component is now enabled');
+                    assert.ok(!$element.hasClass('disabled'), 'The component is now enabled');
                     ready();
-                }, 1 );
-            } );
-    } );
+                }, 1);
+            });
+    });
 
-    QUnit.test( 'change values', function( assert ) {
+    QUnit.test('change values', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 9 );
+        assert.expect(9);
 
-        editorComponent( $container, config )
-            .on( 'render', function() {
+        editorComponent($container, config)
+            .on('render', function() {
                 var self = this;
-                setTimeout( function() {
-                    var $element  = self.getElement();
-                    var $selector = $( '.property-selector', $element );
-                    var values    = self.getValues();
+                setTimeout(function() {
+                    var $element = self.getElement();
+                    var $selector = $('.property-selector', $element);
+                    var values = self.getValues();
 
-                    assert.ok( self.is( 'rendered' ), 'The component is rendered' );
-                    assert.equal( $selector.length, 1, 'The selecor exists' );
+                    assert.ok(self.is('rendered'), 'The component is rendered');
+                    assert.equal($selector.length, 1, 'The selecor exists');
 
-                    assert.deepEqual( values.property, samples.property, 'The property value matches the default config' );
-                    assert.deepEqual( values.selection, samples.selection, 'The selection value matches the default config' );
+                    assert.deepEqual(values.property, samples.property, 'The property value matches the default config');
+                    assert.deepEqual(values.selection, samples.selection, 'The selection value matches the default config');
 
-                    $( '.selected', $selector ).click();
+                    $('.selected', $selector).click();
 
-                    setTimeout( function() {
-                        $( '.options li:first-child a', $selector ).click();
-                    }, 500 );
-                }, 50 );
-            } )
-            .on( 'propertyChange', function( uri, label ) {
-                assert.equal( uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct' );
-                assert.equal( label, 'Identifier', 'The selected label is correct' );
+                    setTimeout(function() {
+                        $('.options li:first-child a', $selector).click();
+                    }, 500);
+                }, 50);
+            })
+            .on('propertyChange', function(uri, label) {
+                assert.equal(uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct');
+                assert.equal(label, 'Identifier', 'The selected label is correct');
 
-                this.refresh( uri, label, selection );
-            } )
-            .on( 'refresh', function() {
-                var values    = this.getValues();
+                this.refresh(uri, label, selection);
+            })
+            .on('refresh', function() {
+                var values = this.getValues();
 
-                assert.equal( values.property.uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct' );
-                assert.equal( values.property.label, 'Identifier', 'The selected label is correct' );
-                assert.deepEqual( values.selection, selection, 'The selection value matches the default config' );
+                assert.equal(values.property.uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct');
+                assert.equal(values.property.label, 'Identifier', 'The selected label is correct');
+                assert.deepEqual(values.selection, selection, 'The selection value matches the default config');
 
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.module( 'Visual' );
+    QUnit.module('Visual');
 
-    QUnit.test( 'playground', function( assert ) {
+    QUnit.test('playground', function(assert) {
         var ready = assert.async();
-        var container = document.getElementById( 'visual' );
+        var container = document.getElementById('visual');
 
-        assert.expect( 1 );
+        assert.expect(1);
 
-        editorComponent( container, { data: samples } )
-            .on( 'render', function() {
-                assert.ok( true );
+        editorComponent(container, {data: samples})
+            .on('render', function() {
+                assert.ok(true);
                 ready();
-            } )
-            .on( 'propertyChange', function( uri, label ) {
+            })
+            .on('propertyChange', function(uri, label) {
                 var self = this;
                 this.disable();
-                this.off( 'resfresh' )
-                    .on( 'refresh', function() {
+                this.off('resfresh')
+                    .on('refresh', function() {
                         this.enable();
-                    } );
-                setTimeout( function() {
-                    self.refresh( uri, label, selection );
-                }, 1500 );
-            } );
-    } );
-} );
+                    });
+                setTimeout(function() {
+                    self.refresh(uri, label, selection);
+                }, 1500);
+            });
+    });
+});

--- a/views/js/test/component/editor/propertySelector/test.html
+++ b/views/js/test/component/editor/propertySelector/test.html
@@ -6,8 +6,8 @@
         <base href="../../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="propertySelector/selector.js"></script>
 

--- a/views/js/test/component/editor/propertySelector/test.js
+++ b/views/js/test/component/editor/propertySelector/test.js
@@ -19,231 +19,237 @@
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-define([
+define( [
+
     'jquery',
     'taoBlueprints/component/editor/propertySelector/selector',
     'json!taoBlueprints/test/component/editor/propertySelector/data.json'
-], function($, propertySelectorComponent, samples) {
+], function(  $, propertySelectorComponent, samples ) {
     'use strict';
 
     var config = {
-        uri  : 'http://taotesting.com/foo#Level',
+        uri: 'http://taotesting.com/foo#Level',
         label: 'Level',
-        data : samples
+        data: samples
     };
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('module', function(assert) {
-        QUnit.expect(3);
+    QUnit.test( 'module', function( assert ) {
+        assert.expect( 3 );
 
-        assert.equal(typeof propertySelectorComponent, 'function', "The propertySelectorComponent module exposes a function");
-        assert.equal(typeof propertySelectorComponent(null, config), 'object', "The propertySelectorComponent factory produces an object");
-        assert.notStrictEqual(propertySelectorComponent(null, config), propertySelectorComponent(null, config), "The propertySelectorComponent factory provides a different object on each call");
-    });
+        assert.equal( typeof propertySelectorComponent, 'function', 'The propertySelectorComponent module exposes a function' );
+        assert.equal( typeof propertySelectorComponent( null, config ), 'object', 'The propertySelectorComponent factory produces an object' );
+        assert.notStrictEqual( propertySelectorComponent( null, config ), propertySelectorComponent( null, config ), 'The propertySelectorComponent factory provides a different object on each call' );
+    } );
 
-    QUnit.cases([
-        { name : 'init',         title : 'init' },
-        { name : 'destroy',      title : 'destroy' },
-        { name : 'render',       title : 'render' },
-        { name : 'show',         title : 'show' },
-        { name : 'hide',         title : 'hide' },
-        { name : 'enable',       title : 'enable' },
-        { name : 'disable',      title : 'disable' },
-        { name : 'is',           title : 'is' },
-        { name : 'setState',     title : 'setState' },
-        { name : 'getContainer', title : 'getContainer' },
-        { name : 'getElement',   title : 'getElement' },
-        { name : 'getTemplate',  title : 'getTemplate' },
-        { name : 'setTemplate',  title : 'setTemplate' }
-    ])
-    .test('component ', function(data, assert) {
-        var instance = propertySelectorComponent(null, config);
-        assert.equal(typeof instance[data.name], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function');
-    });
+    QUnit.cases.init( [
+        { name: 'init',         title: 'init' },
+        { name: 'destroy',      title: 'destroy' },
+        { name: 'render',       title: 'render' },
+        { name: 'show',         title: 'show' },
+        { name: 'hide',         title: 'hide' },
+        { name: 'enable',       title: 'enable' },
+        { name: 'disable',      title: 'disable' },
+        { name: 'is',           title: 'is' },
+        { name: 'setState',     title: 'setState' },
+        { name: 'getContainer', title: 'getContainer' },
+        { name: 'getElement',   title: 'getElement' },
+        { name: 'getTemplate',  title: 'getTemplate' },
+        { name: 'setTemplate',  title: 'setTemplate' }
+    ] )
+    .test( 'component ', function( data, assert ) {
+        var instance = propertySelectorComponent( null, config );
+        assert.equal( typeof instance[ data.name ], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function' );
+    } );
 
-    QUnit.cases([
-        { name : 'on',      title : 'on' },
-        { name : 'off',     title : 'off' },
-        { name : 'trigger', title : 'trigger' }
-    ])
-    .test('eventifier ', function(data, assert) {
-        var instance = propertySelectorComponent(null, config);
-        assert.equal(typeof instance[data.name], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function');
-    });
+    QUnit.cases.init( [
+        { name: 'on',      title: 'on' },
+        { name: 'off',     title: 'off' },
+        { name: 'trigger', title: 'trigger' }
+    ] )
+    .test( 'eventifier ', function( data, assert ) {
+        var instance = propertySelectorComponent( null, config );
+        assert.equal( typeof instance[ data.name ], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function' );
+    } );
 
-    QUnit.cases([
-        { name : 'getSelected', title : 'getSelected' }
-    ])
-    .test('spec ', function(data, assert) {
-        var instance = propertySelectorComponent(null, config);
-        assert.equal(typeof instance[data.name], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function');
-    });
+    QUnit.cases.init( [
+        { name: 'getSelected', title: 'getSelected' }
+    ] )
+    .test( 'spec ', function( data, assert ) {
+        var instance = propertySelectorComponent( null, config );
+        assert.equal( typeof instance[ data.name ], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function' );
+    } );
 
+    QUnit.module( 'Behavior' );
 
-    QUnit.module('Behavior');
+    QUnit.test( 'DOM rendering', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-    QUnit.asyncTest('DOM rendering', function(assert) {
-        var $container = $('#qunit-fixture');
-
-        QUnit.expect(13);
-
-        propertySelectorComponent( $container, config )
-            .on('render', function(){
-                var $element = $('.property-selector ', $container);
-
-                assert.equal($element.length, 1, 'The container has the component root element');
-                assert.ok($element.hasClass('rendered'), 1, 'The component root element has the rendered class');
-
-                assert.equal($element.children('a').length, 1, 'The component has an anchor element');
-                assert.ok($element.children('a').hasClass('selected'), 'The anchor is the selected element');
-                assert.equal($element.children('a').data('uri'), 'http://taotesting.com/foo#Level', 'The anchor is the selected element');
-
-                assert.equal($element.children('div').length, 1, 'The component has an div child element');
-                assert.ok($element.children('div').hasClass('options'), 'The div child is the selected element');
-
-                assert.equal($('.options ul li', $element).length, 6, 'The component has the correct number of items');
-
-                assert.equal($('.options ul li:first-child a', $element).data('uri'),  'http://taotesting.com/foo#Identifier', 'The item has the correct URI');
-                assert.equal($('.options ul li:first-child a', $element).text(),  'Identifier', 'The item has the correct label');
-
-                assert.equal($('.options ul li:last-child a', $element).data('uri'),  'http://taotesting.com/foo#Target', 'The item has the correct URI');
-                assert.equal($('.options ul li:last-child a', $element).text(),  'Target', 'The item has the correct label');
-
-                assert.deepEqual($element[0], this.getElement()[0], 'The element is the one bound to the component');
-
-                QUnit.start();
-            });
-    });
-
-    QUnit.asyncTest('mounting lifecycle', function(assert) {
-        var $container = $('#qunit-fixture');
-
-        QUnit.expect(4);
+        assert.expect( 13 );
 
         propertySelectorComponent( $container, config )
-            .on('init', function(){
-                assert.ok( ! this.is('rendered'), 'The component is not yet rendered');
-                assert.equal($('.property-selector', $container).length, 0, 'The component is not yet appended');
-            })
-            .on('render', function(){
+            .on( 'render', function() {
+                var $element = $( '.property-selector ', $container );
 
-                assert.ok(this.is('rendered'), 'The component is rendered');
-                assert.equal($('.property-selector', $container).length, 1, 'The component is  appended');
+                assert.equal( $element.length, 1, 'The container has the component root element' );
+                assert.ok( $element.hasClass( 'rendered' ), 1, 'The component root element has the rendered class' );
+
+                assert.equal( $element.children( 'a' ).length, 1, 'The component has an anchor element' );
+                assert.ok( $element.children( 'a' ).hasClass( 'selected' ), 'The anchor is the selected element' );
+                assert.equal( $element.children( 'a' ).data( 'uri' ), 'http://taotesting.com/foo#Level', 'The anchor is the selected element' );
+
+                assert.equal( $element.children( 'div' ).length, 1, 'The component has an div child element' );
+                assert.ok( $element.children( 'div' ).hasClass( 'options' ), 'The div child is the selected element' );
+
+                assert.equal( $( '.options ul li', $element ).length, 6, 'The component has the correct number of items' );
+
+                assert.equal( $( '.options ul li:first-child a', $element ).data( 'uri' ),  'http://taotesting.com/foo#Identifier', 'The item has the correct URI' );
+                assert.equal( $( '.options ul li:first-child a', $element ).text(),  'Identifier', 'The item has the correct label' );
+
+                assert.equal( $( '.options ul li:last-child a', $element ).data( 'uri' ),  'http://taotesting.com/foo#Target', 'The item has the correct URI' );
+                assert.equal( $( '.options ul li:last-child a', $element ).text(),  'Target', 'The item has the correct label' );
+
+                assert.deepEqual( $element[ 0 ], this.getElement()[ 0 ], 'The element is the one bound to the component' );
+
+                ready();
+            } );
+    } );
+
+    QUnit.test( 'mounting lifecycle', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
+
+        assert.expect( 4 );
+
+        propertySelectorComponent( $container, config )
+            .on( 'init', function() {
+                assert.ok( !this.is( 'rendered' ), 'The component is not yet rendered' );
+                assert.equal( $( '.property-selector', $container ).length, 0, 'The component is not yet appended' );
+            } )
+            .on( 'render', function() {
+
+                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
+                assert.equal( $( '.property-selector', $container ).length, 1, 'The component is  appended' );
 
                 this.destroy();
-            })
-            .on('destroy', function(){
-                QUnit.start();
-            });
-    });
+            } )
+            .on( 'destroy', function() {
+                ready();
+            } );
+    } );
 
-    QUnit.asyncTest('start empty', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'start empty', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-        QUnit.expect(6);
+        assert.expect( 6 );
 
-        propertySelectorComponent( $container, { data : samples } )
-            .on('render', function(){
-                var $element = $('.property-selector ', $container);
-                var $selected = $('.selected', $element);
+        propertySelectorComponent( $container, { data: samples } )
+            .on( 'render', function() {
+                var $element = $( '.property-selector ', $container );
+                var $selected = $( '.selected', $element );
 
-                assert.equal($element.length, 1, 'The container has the component root element');
-                assert.ok($element.hasClass('rendered'), 1, 'The component root element has the rendered class');
+                assert.equal( $element.length, 1, 'The container has the component root element' );
+                assert.ok( $element.hasClass( 'rendered' ), 1, 'The component root element has the rendered class' );
 
-                assert.equal($selected.length, 1, 'The selected element exists');
-                assert.ok($selected.hasClass('empty'), 'The selected element is empty');
-                assert.equal($selected.data('uri'), null, 'The selected element as no URI');
-                assert.equal($selected.text().trim(), 'Please select a property', 'The default empty text is correct');
+                assert.equal( $selected.length, 1, 'The selected element exists' );
+                assert.ok( $selected.hasClass( 'empty' ), 'The selected element is empty' );
+                assert.equal( $selected.data( 'uri' ), null, 'The selected element as no URI' );
+                assert.equal( $selected.text().trim(), 'Please select a property', 'The default empty text is correct' );
 
-                QUnit.start();
-            });
-    });
+                ready();
+            } );
+    } );
 
-    QUnit.asyncTest('select a value', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'select a value', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-        QUnit.expect(7);
+        assert.expect( 7 );
 
         propertySelectorComponent( $container, config )
-            .on('render', function(){
-                var $element = $('.property-selector ', $container);
-                var $selected = $('.selected', $element);
-                var $options = $('.options', $element);
+            .on( 'render', function() {
+                var $element = $( '.property-selector ', $container );
+                var $selected = $( '.selected', $element );
+                var $options = $( '.options', $element );
 
-                assert.equal($element.length, 1, 'The container has the component root element');
-                assert.ok($element.hasClass('rendered'), 'The component root element has the rendered class');
-                assert.equal($selected.data('uri'), 'http://taotesting.com/foo#Level', 'The anchor is the selected element');
+                assert.equal( $element.length, 1, 'The container has the component root element' );
+                assert.ok( $element.hasClass( 'rendered' ), 'The component root element has the rendered class' );
+                assert.equal( $selected.data( 'uri' ), 'http://taotesting.com/foo#Level', 'The anchor is the selected element' );
 
-                assert.ok($options.hasClass('folded'), 'The options element starts folded');
+                assert.ok( $options.hasClass( 'folded' ), 'The options element starts folded' );
 
                 $selected.click();
 
-                setTimeout(function(){
-                    assert.ok( ! $options.hasClass('folded'), 'The options element is shown');
+                setTimeout( function() {
+                    assert.ok( !$options.hasClass( 'folded' ), 'The options element is shown' );
 
-                    $('li:first-child a', $options).click();
+                    $( 'li:first-child a', $options ).click();
 
-                }, 500);
+                }, 500 );
 
-            })
-            .on('change', function(uri, label){
+            } )
+            .on( 'change', function( uri, label ) {
 
-                assert.equal(uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct');
-                assert.equal(label, 'Identifier', 'The selected label is correct');
-                QUnit.start();
-            });
-    });
+                assert.equal( uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct' );
+                assert.equal( label, 'Identifier', 'The selected label is correct' );
+                ready();
+            } );
+    } );
 
-    QUnit.asyncTest('get selected', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'get selected', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
-        QUnit.expect(11);
+        assert.expect( 11 );
 
         propertySelectorComponent( $container, config )
-            .on('render', function(){
-                var $element = $('.property-selector ', $container);
-                var $selected = $('.selected', $element);
-                var $options = $('.options', $element);
+            .on( 'render', function() {
+                var $element = $( '.property-selector ', $container );
+                var $selected = $( '.selected', $element );
+                var $options = $( '.options', $element );
                 var selectedValues = this.getSelected();
 
-                assert.equal($element.length, 1, 'The container has the component root element');
-                assert.ok($element.hasClass('rendered'), 'The component root element has the rendered class');
-                assert.equal($selected.data('uri'), 'http://taotesting.com/foo#Level', 'The anchor is the selected element');
+                assert.equal( $element.length, 1, 'The container has the component root element' );
+                assert.ok( $element.hasClass( 'rendered' ), 'The component root element has the rendered class' );
+                assert.equal( $selected.data( 'uri' ), 'http://taotesting.com/foo#Level', 'The anchor is the selected element' );
 
-                assert.equal(typeof selectedValues, 'object', 'The selected values is an object');
-                assert.equal(selectedValues.uri,  'http://taotesting.com/foo#Level', 'The selected URI is correct');
-                assert.equal(selectedValues.label,  'Level', 'The selected label is correct');
+                assert.equal( typeof selectedValues, 'object', 'The selected values is an object' );
+                assert.equal( selectedValues.uri,  'http://taotesting.com/foo#Level', 'The selected URI is correct' );
+                assert.equal( selectedValues.label,  'Level', 'The selected label is correct' );
 
                 $selected.click();
 
-                setTimeout(function(){
-                    $('li:first-child a', $options).click();
-                }, 500);
-            })
-            .on('change', function(uri, label){
+                setTimeout( function() {
+                    $( 'li:first-child a', $options ).click();
+                }, 500 );
+            } )
+            .on( 'change', function( uri, label ) {
                 var selectedValues = this.getSelected();
-                assert.equal(uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct');
-                assert.equal(label, 'Identifier', 'The selected label is correct');
-                assert.equal(typeof selectedValues, 'object', 'The selected values is an object');
-                assert.equal(selectedValues.uri,  uri, 'The selected URI is correct');
-                assert.equal(selectedValues.label,  label, 'The selected label is correct');
-                QUnit.start();
-            });
-    });
+                assert.equal( uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct' );
+                assert.equal( label, 'Identifier', 'The selected label is correct' );
+                assert.equal( typeof selectedValues, 'object', 'The selected values is an object' );
+                assert.equal( selectedValues.uri,  uri, 'The selected URI is correct' );
+                assert.equal( selectedValues.label,  label, 'The selected label is correct' );
+                ready();
+            } );
+    } );
 
-    QUnit.module('Visual');
+    QUnit.module( 'Visual' );
 
-    QUnit.asyncTest('playground', function(assert) {
-        var container = document.getElementById('visual');
+    QUnit.test( 'playground', function( assert ) {
+        var ready = assert.async();
+        var container = document.getElementById( 'visual' );
 
-        QUnit.expect(1);
+        assert.expect( 1 );
 
-        propertySelectorComponent( container, config)
-            .on('render', function(){
-                assert.ok(true);
-                QUnit.start();
-            });
-    });
+        propertySelectorComponent( container, config )
+            .on( 'render', function() {
+                assert.ok( true );
+                ready();
+            } );
+    } );
 
-});
+} );

--- a/views/js/test/component/editor/propertySelector/test.js
+++ b/views/js/test/component/editor/propertySelector/test.js
@@ -19,12 +19,12 @@
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-define( [
+define([
 
     'jquery',
     'taoBlueprints/component/editor/propertySelector/selector',
     'json!taoBlueprints/test/component/editor/propertySelector/data.json'
-], function(  $, propertySelectorComponent, samples ) {
+], function($, propertySelectorComponent, samples) {
     'use strict';
 
     var config = {
@@ -33,223 +33,223 @@ define( [
         data: samples
     };
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.expect( 3 );
+    QUnit.test('module', function(assert) {
+        assert.expect(3);
 
-        assert.equal( typeof propertySelectorComponent, 'function', 'The propertySelectorComponent module exposes a function' );
-        assert.equal( typeof propertySelectorComponent( null, config ), 'object', 'The propertySelectorComponent factory produces an object' );
-        assert.notStrictEqual( propertySelectorComponent( null, config ), propertySelectorComponent( null, config ), 'The propertySelectorComponent factory provides a different object on each call' );
-    } );
+        assert.equal(typeof propertySelectorComponent, 'function', 'The propertySelectorComponent module exposes a function');
+        assert.equal(typeof propertySelectorComponent(null, config), 'object', 'The propertySelectorComponent factory produces an object');
+        assert.notStrictEqual(propertySelectorComponent(null, config), propertySelectorComponent(null, config), 'The propertySelectorComponent factory provides a different object on each call');
+    });
 
-    QUnit.cases.init( [
-        { name: 'init',         title: 'init' },
-        { name: 'destroy',      title: 'destroy' },
-        { name: 'render',       title: 'render' },
-        { name: 'show',         title: 'show' },
-        { name: 'hide',         title: 'hide' },
-        { name: 'enable',       title: 'enable' },
-        { name: 'disable',      title: 'disable' },
-        { name: 'is',           title: 'is' },
-        { name: 'setState',     title: 'setState' },
-        { name: 'getContainer', title: 'getContainer' },
-        { name: 'getElement',   title: 'getElement' },
-        { name: 'getTemplate',  title: 'getTemplate' },
-        { name: 'setTemplate',  title: 'setTemplate' }
-    ] )
-    .test( 'component ', function( data, assert ) {
-        var instance = propertySelectorComponent( null, config );
-        assert.equal( typeof instance[ data.name ], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function' );
-    } );
+    QUnit.cases.init([
+        {name: 'init', title: 'init'},
+        {name: 'destroy', title: 'destroy'},
+        {name: 'render', title: 'render'},
+        {name: 'show', title: 'show'},
+        {name: 'hide', title: 'hide'},
+        {name: 'enable', title: 'enable'},
+        {name: 'disable', title: 'disable'},
+        {name: 'is', title: 'is'},
+        {name: 'setState', title: 'setState'},
+        {name: 'getContainer', title: 'getContainer'},
+        {name: 'getElement', title: 'getElement'},
+        {name: 'getTemplate', title: 'getTemplate'},
+        {name: 'setTemplate', title: 'setTemplate'}
+    ])
+    .test('component ', function(data, assert) {
+        var instance = propertySelectorComponent(null, config);
+        assert.equal(typeof instance[data.name], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function');
+    });
 
-    QUnit.cases.init( [
-        { name: 'on',      title: 'on' },
-        { name: 'off',     title: 'off' },
-        { name: 'trigger', title: 'trigger' }
-    ] )
-    .test( 'eventifier ', function( data, assert ) {
-        var instance = propertySelectorComponent( null, config );
-        assert.equal( typeof instance[ data.name ], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function' );
-    } );
+    QUnit.cases.init([
+        {name: 'on', title: 'on'},
+        {name: 'off', title: 'off'},
+        {name: 'trigger', title: 'trigger'}
+    ])
+    .test('eventifier ', function(data, assert) {
+        var instance = propertySelectorComponent(null, config);
+        assert.equal(typeof instance[data.name], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function');
+    });
 
-    QUnit.cases.init( [
-        { name: 'getSelected', title: 'getSelected' }
-    ] )
-    .test( 'spec ', function( data, assert ) {
-        var instance = propertySelectorComponent( null, config );
-        assert.equal( typeof instance[ data.name ], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function' );
-    } );
+    QUnit.cases.init([
+        {name: 'getSelected', title: 'getSelected'}
+    ])
+    .test('spec ', function(data, assert) {
+        var instance = propertySelectorComponent(null, config);
+        assert.equal(typeof instance[data.name], 'function', 'The propertySelectorComponent instance exposes a "' + data.title + '" function');
+    });
 
-    QUnit.module( 'Behavior' );
+    QUnit.module('Behavior');
 
-    QUnit.test( 'DOM rendering', function( assert ) {
+    QUnit.test('DOM rendering', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 13 );
+        assert.expect(13);
 
-        propertySelectorComponent( $container, config )
-            .on( 'render', function() {
-                var $element = $( '.property-selector ', $container );
+        propertySelectorComponent($container, config)
+            .on('render', function() {
+                var $element = $('.property-selector ', $container);
 
-                assert.equal( $element.length, 1, 'The container has the component root element' );
-                assert.ok( $element.hasClass( 'rendered' ), 1, 'The component root element has the rendered class' );
+                assert.equal($element.length, 1, 'The container has the component root element');
+                assert.ok($element.hasClass('rendered'), 1, 'The component root element has the rendered class');
 
-                assert.equal( $element.children( 'a' ).length, 1, 'The component has an anchor element' );
-                assert.ok( $element.children( 'a' ).hasClass( 'selected' ), 'The anchor is the selected element' );
-                assert.equal( $element.children( 'a' ).data( 'uri' ), 'http://taotesting.com/foo#Level', 'The anchor is the selected element' );
+                assert.equal($element.children('a').length, 1, 'The component has an anchor element');
+                assert.ok($element.children('a').hasClass('selected'), 'The anchor is the selected element');
+                assert.equal($element.children('a').data('uri'), 'http://taotesting.com/foo#Level', 'The anchor is the selected element');
 
-                assert.equal( $element.children( 'div' ).length, 1, 'The component has an div child element' );
-                assert.ok( $element.children( 'div' ).hasClass( 'options' ), 'The div child is the selected element' );
+                assert.equal($element.children('div').length, 1, 'The component has an div child element');
+                assert.ok($element.children('div').hasClass('options'), 'The div child is the selected element');
 
-                assert.equal( $( '.options ul li', $element ).length, 6, 'The component has the correct number of items' );
+                assert.equal($('.options ul li', $element).length, 6, 'The component has the correct number of items');
 
-                assert.equal( $( '.options ul li:first-child a', $element ).data( 'uri' ),  'http://taotesting.com/foo#Identifier', 'The item has the correct URI' );
-                assert.equal( $( '.options ul li:first-child a', $element ).text(),  'Identifier', 'The item has the correct label' );
+                assert.equal($('.options ul li:first-child a', $element).data('uri'), 'http://taotesting.com/foo#Identifier', 'The item has the correct URI');
+                assert.equal($('.options ul li:first-child a', $element).text(), 'Identifier', 'The item has the correct label');
 
-                assert.equal( $( '.options ul li:last-child a', $element ).data( 'uri' ),  'http://taotesting.com/foo#Target', 'The item has the correct URI' );
-                assert.equal( $( '.options ul li:last-child a', $element ).text(),  'Target', 'The item has the correct label' );
+                assert.equal($('.options ul li:last-child a', $element).data('uri'), 'http://taotesting.com/foo#Target', 'The item has the correct URI');
+                assert.equal($('.options ul li:last-child a', $element).text(), 'Target', 'The item has the correct label');
 
-                assert.deepEqual( $element[ 0 ], this.getElement()[ 0 ], 'The element is the one bound to the component' );
+                assert.deepEqual($element[0], this.getElement()[0], 'The element is the one bound to the component');
 
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.test( 'mounting lifecycle', function( assert ) {
+    QUnit.test('mounting lifecycle', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 4 );
+        assert.expect(4);
 
-        propertySelectorComponent( $container, config )
-            .on( 'init', function() {
-                assert.ok( !this.is( 'rendered' ), 'The component is not yet rendered' );
-                assert.equal( $( '.property-selector', $container ).length, 0, 'The component is not yet appended' );
-            } )
-            .on( 'render', function() {
+        propertySelectorComponent($container, config)
+            .on('init', function() {
+                assert.ok(!this.is('rendered'), 'The component is not yet rendered');
+                assert.equal($('.property-selector', $container).length, 0, 'The component is not yet appended');
+            })
+            .on('render', function() {
 
-                assert.ok( this.is( 'rendered' ), 'The component is rendered' );
-                assert.equal( $( '.property-selector', $container ).length, 1, 'The component is  appended' );
+                assert.ok(this.is('rendered'), 'The component is rendered');
+                assert.equal($('.property-selector', $container).length, 1, 'The component is  appended');
 
                 this.destroy();
-            } )
-            .on( 'destroy', function() {
+            })
+            .on('destroy', function() {
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.test( 'start empty', function( assert ) {
+    QUnit.test('start empty', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 6 );
+        assert.expect(6);
 
-        propertySelectorComponent( $container, { data: samples } )
-            .on( 'render', function() {
-                var $element = $( '.property-selector ', $container );
-                var $selected = $( '.selected', $element );
+        propertySelectorComponent($container, {data: samples})
+            .on('render', function() {
+                var $element = $('.property-selector ', $container);
+                var $selected = $('.selected', $element);
 
-                assert.equal( $element.length, 1, 'The container has the component root element' );
-                assert.ok( $element.hasClass( 'rendered' ), 1, 'The component root element has the rendered class' );
+                assert.equal($element.length, 1, 'The container has the component root element');
+                assert.ok($element.hasClass('rendered'), 1, 'The component root element has the rendered class');
 
-                assert.equal( $selected.length, 1, 'The selected element exists' );
-                assert.ok( $selected.hasClass( 'empty' ), 'The selected element is empty' );
-                assert.equal( $selected.data( 'uri' ), null, 'The selected element as no URI' );
-                assert.equal( $selected.text().trim(), 'Please select a property', 'The default empty text is correct' );
+                assert.equal($selected.length, 1, 'The selected element exists');
+                assert.ok($selected.hasClass('empty'), 'The selected element is empty');
+                assert.equal($selected.data('uri'), null, 'The selected element as no URI');
+                assert.equal($selected.text().trim(), 'Please select a property', 'The default empty text is correct');
 
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.test( 'select a value', function( assert ) {
+    QUnit.test('select a value', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 7 );
+        assert.expect(7);
 
-        propertySelectorComponent( $container, config )
-            .on( 'render', function() {
-                var $element = $( '.property-selector ', $container );
-                var $selected = $( '.selected', $element );
-                var $options = $( '.options', $element );
+        propertySelectorComponent($container, config)
+            .on('render', function() {
+                var $element = $('.property-selector ', $container);
+                var $selected = $('.selected', $element);
+                var $options = $('.options', $element);
 
-                assert.equal( $element.length, 1, 'The container has the component root element' );
-                assert.ok( $element.hasClass( 'rendered' ), 'The component root element has the rendered class' );
-                assert.equal( $selected.data( 'uri' ), 'http://taotesting.com/foo#Level', 'The anchor is the selected element' );
+                assert.equal($element.length, 1, 'The container has the component root element');
+                assert.ok($element.hasClass('rendered'), 'The component root element has the rendered class');
+                assert.equal($selected.data('uri'), 'http://taotesting.com/foo#Level', 'The anchor is the selected element');
 
-                assert.ok( $options.hasClass( 'folded' ), 'The options element starts folded' );
+                assert.ok($options.hasClass('folded'), 'The options element starts folded');
 
                 $selected.click();
 
-                setTimeout( function() {
-                    assert.ok( !$options.hasClass( 'folded' ), 'The options element is shown' );
+                setTimeout(function() {
+                    assert.ok(!$options.hasClass('folded'), 'The options element is shown');
 
-                    $( 'li:first-child a', $options ).click();
+                    $('li:first-child a', $options).click();
 
-                }, 500 );
+                }, 500);
 
-            } )
-            .on( 'change', function( uri, label ) {
+            })
+            .on('change', function(uri, label) {
 
-                assert.equal( uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct' );
-                assert.equal( label, 'Identifier', 'The selected label is correct' );
+                assert.equal(uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct');
+                assert.equal(label, 'Identifier', 'The selected label is correct');
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.test( 'get selected', function( assert ) {
+    QUnit.test('get selected', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 11 );
+        assert.expect(11);
 
-        propertySelectorComponent( $container, config )
-            .on( 'render', function() {
-                var $element = $( '.property-selector ', $container );
-                var $selected = $( '.selected', $element );
-                var $options = $( '.options', $element );
+        propertySelectorComponent($container, config)
+            .on('render', function() {
+                var $element = $('.property-selector ', $container);
+                var $selected = $('.selected', $element);
+                var $options = $('.options', $element);
                 var selectedValues = this.getSelected();
 
-                assert.equal( $element.length, 1, 'The container has the component root element' );
-                assert.ok( $element.hasClass( 'rendered' ), 'The component root element has the rendered class' );
-                assert.equal( $selected.data( 'uri' ), 'http://taotesting.com/foo#Level', 'The anchor is the selected element' );
+                assert.equal($element.length, 1, 'The container has the component root element');
+                assert.ok($element.hasClass('rendered'), 'The component root element has the rendered class');
+                assert.equal($selected.data('uri'), 'http://taotesting.com/foo#Level', 'The anchor is the selected element');
 
-                assert.equal( typeof selectedValues, 'object', 'The selected values is an object' );
-                assert.equal( selectedValues.uri,  'http://taotesting.com/foo#Level', 'The selected URI is correct' );
-                assert.equal( selectedValues.label,  'Level', 'The selected label is correct' );
+                assert.equal(typeof selectedValues, 'object', 'The selected values is an object');
+                assert.equal(selectedValues.uri, 'http://taotesting.com/foo#Level', 'The selected URI is correct');
+                assert.equal(selectedValues.label, 'Level', 'The selected label is correct');
 
                 $selected.click();
 
-                setTimeout( function() {
-                    $( 'li:first-child a', $options ).click();
-                }, 500 );
-            } )
-            .on( 'change', function( uri, label ) {
+                setTimeout(function() {
+                    $('li:first-child a', $options).click();
+                }, 500);
+            })
+            .on('change', function(uri, label) {
                 var selectedValues = this.getSelected();
-                assert.equal( uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct' );
-                assert.equal( label, 'Identifier', 'The selected label is correct' );
-                assert.equal( typeof selectedValues, 'object', 'The selected values is an object' );
-                assert.equal( selectedValues.uri,  uri, 'The selected URI is correct' );
-                assert.equal( selectedValues.label,  label, 'The selected label is correct' );
+                assert.equal(uri, 'http://taotesting.com/foo#Identifier', 'The selected URI is correct');
+                assert.equal(label, 'Identifier', 'The selected label is correct');
+                assert.equal(typeof selectedValues, 'object', 'The selected values is an object');
+                assert.equal(selectedValues.uri, uri, 'The selected URI is correct');
+                assert.equal(selectedValues.label, label, 'The selected label is correct');
                 ready();
-            } );
-    } );
+            });
+    });
 
-    QUnit.module( 'Visual' );
+    QUnit.module('Visual');
 
-    QUnit.test( 'playground', function( assert ) {
+    QUnit.test('playground', function(assert) {
         var ready = assert.async();
-        var container = document.getElementById( 'visual' );
+        var container = document.getElementById('visual');
 
-        assert.expect( 1 );
+        assert.expect(1);
 
-        propertySelectorComponent( container, config )
-            .on( 'render', function() {
-                assert.ok( true );
+        propertySelectorComponent(container, config)
+            .on('render', function() {
+                assert.ok(true);
                 ready();
-            } );
-    } );
+            });
+    });
 
-} );
+});

--- a/views/js/test/provider/editor/test.html
+++ b/views/js/test/provider/editor/test.html
@@ -6,8 +6,8 @@
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="provider/editor.js"></script>
 

--- a/views/js/test/provider/editor/test.js
+++ b/views/js/test/provider/editor/test.js
@@ -19,12 +19,12 @@
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-define( [
-    
+define([
+
     'taoBlueprints/provider/editor',
     'core/promise',
     'json!taoBlueprints/test/provider/editor/saveSample.json'
-], function(  editorProvider, Promise, saveSample ) {
+], function(editorProvider, Promise, saveSample) {
     'use strict';
 
     var testConfig = {
@@ -39,189 +39,189 @@ define( [
         }
     };
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.expect( 3 );
+    QUnit.test('module', function(assert) {
+        assert.expect(3);
 
-        assert.equal( typeof editorProvider, 'function', 'The editorProvider module exposes a function' );
-        assert.equal( typeof editorProvider(), 'object', 'The editorProvider factory produces an object' );
-        assert.notStrictEqual( editorProvider(), editorProvider(), 'The editorProvider factory provides a different object on each call' );
-    } );
+        assert.equal(typeof editorProvider, 'function', 'The editorProvider module exposes a function');
+        assert.equal(typeof editorProvider(), 'object', 'The editorProvider factory produces an object');
+        assert.notStrictEqual(editorProvider(), editorProvider(), 'The editorProvider factory provides a different object on each call');
+    });
 
-    QUnit.test( 'methods', function( assert ) {
+    QUnit.test('methods', function(assert) {
         var provider = editorProvider();
 
-        assert.expect( 4 );
+        assert.expect(4);
 
-        assert.equal( typeof provider, 'object', 'The editorProvider factory produces an object' );
-        assert.equal( typeof provider.get, 'function', 'The provider exposes the get method' );
-        assert.equal( typeof provider.save, 'function', 'The provider exposes the save method' );
-        assert.equal( typeof provider.getSelection, 'function', 'The provider exposes the getSelection method' );
-    } );
+        assert.equal(typeof provider, 'object', 'The editorProvider factory produces an object');
+        assert.equal(typeof provider.get, 'function', 'The provider exposes the get method');
+        assert.equal(typeof provider.save, 'function', 'The provider exposes the save method');
+        assert.equal(typeof provider.getSelection, 'function', 'The provider exposes the getSelection method');
+    });
 
-    QUnit.module( 'get' );
+    QUnit.module('get');
 
-    QUnit.test( 'success', function( assert ) {
+    QUnit.test('success', function(assert) {
         var ready = assert.async();
         var p;
-        var provider = editorProvider( testConfig );
+        var provider = editorProvider(testConfig);
 
-        assert.expect( 3 );
+        assert.expect(3);
 
-        p = provider.get( 'http://www.my-tao.com#blueprint1' );
+        p = provider.get('http://www.my-tao.com#blueprint1');
 
-        assert.ok( p instanceof Promise, 'The method returns a Promise' );
+        assert.ok(p instanceof Promise, 'The method returns a Promise');
 
-        p.then( function( data ) {
-            assert.equal( typeof data, 'object', 'The method resolve with an object' );
-            assert.equal( data.property.uri, 'http://www.my-tao.com#topicArea', 'The method resolve with the correct object' );
+        p.then(function(data) {
+            assert.equal(typeof data, 'object', 'The method resolve with an object');
+            assert.equal(data.property.uri, 'http://www.my-tao.com#topicArea', 'The method resolve with the correct object');
             ready();
-        } ).catch( function( err ) {
-            assert.ok( false, 'The method should not reject : ' + err.message );
+        }).catch(function(err) {
+            assert.ok(false, 'The method should not reject : ' + err.message);
             ready();
-        } );
-    } );
+        });
+    });
 
-    QUnit.test( 'no uri', function( assert ) {
+    QUnit.test('no uri', function(assert) {
         var ready = assert.async();
         var provider;
 
-        assert.expect( 2 );
+        assert.expect(2);
 
-        provider = editorProvider( testConfig );
+        provider = editorProvider(testConfig);
 
-        provider.get().then( function() {
-            assert.ok( false, 'The method must not resolve' );
+        provider.get().then(function() {
+            assert.ok(false, 'The method must not resolve');
             ready();
-        } ).catch( function( err ) {
-            assert.ok( err instanceof TypeError, 'The method rejects' );
-            assert.equal( err.message, 'The blueprint URI parameter must be provided', 'The method rejects with the correct message' );
+        }).catch(function(err) {
+            assert.ok(err instanceof TypeError, 'The method rejects');
+            assert.equal(err.message, 'The blueprint URI parameter must be provided', 'The method rejects with the correct message');
             ready();
-        } );
-    } );
+        });
+    });
 
-    QUnit.test( 'empty', function( assert ) {
+    QUnit.test('empty', function(assert) {
         var ready = assert.async();
 
-        var provider = editorProvider( {
+        var provider = editorProvider({
             get: {
                 url: '/taoBlueprints/views/js/test/provider/editor/empty.json'
             }
-        } );
+        });
 
-        assert.expect( 1 );
+        assert.expect(1);
 
-        provider.get( 'http://www.my-tao.com#blueprint1' ).then( function( data ) {
-            assert.equal( typeof data, 'undefined', 'The method resolve without content' );
+        provider.get('http://www.my-tao.com#blueprint1').then(function(data) {
+            assert.equal(typeof data, 'undefined', 'The method resolve without content');
             ready();
-        } ).catch( function( err ) {
-            assert.ok( false, 'The method should not reject : ' + err.message );
+        }).catch(function(err) {
+            assert.ok(false, 'The method should not reject : ' + err.message);
             ready();
-        } );
-    } );
+        });
+    });
 
-    QUnit.module( 'save' );
+    QUnit.module('save');
 
-    QUnit.test( 'success', function( assert ) {
+    QUnit.test('success', function(assert) {
         var ready = assert.async();
         var p, provider;
 
-        assert.expect( 2 );
+        assert.expect(2);
 
-        provider = editorProvider( testConfig );
-        p = provider.save( 'http://www.my-tao.com#blueprint1', saveSample );
+        provider = editorProvider(testConfig);
+        p = provider.save('http://www.my-tao.com#blueprint1', saveSample);
 
-        assert.ok( p instanceof Promise, 'The method returns a Promise' );
+        assert.ok(p instanceof Promise, 'The method returns a Promise');
 
-        p.then( function( success ) {
+        p.then(function(success) {
 
-            assert.ok( success, 'The save method succeed' );
+            assert.ok(success, 'The save method succeed');
 
             ready();
-        } ).catch( function( err ) {
-            assert.ok( false, 'The method should not reject : ' + err.message );
+        }).catch(function(err) {
+            assert.ok(false, 'The method should not reject : ' + err.message);
             ready();
-        } );
-    } );
+        });
+    });
 
-    QUnit.test( 'no uri', function( assert ) {
+    QUnit.test('no uri', function(assert) {
         var ready = assert.async();
         var provider;
 
-        assert.expect( 2 );
+        assert.expect(2);
 
-        provider = editorProvider( testConfig );
+        provider = editorProvider(testConfig);
 
-        provider.save().then( function() {
-            assert.ok( false, 'The method must not resolve' );
+        provider.save().then(function() {
+            assert.ok(false, 'The method must not resolve');
             ready();
-        } ).catch( function( err ) {
-            assert.ok( err instanceof TypeError, 'The method rejects' );
-            assert.equal( err.message, 'The blueprint URI parameter must be provided', 'The method rejects with the correct message' );
+        }).catch(function(err) {
+            assert.ok(err instanceof TypeError, 'The method rejects');
+            assert.equal(err.message, 'The blueprint URI parameter must be provided', 'The method rejects with the correct message');
             ready();
-        } );
-    } );
+        });
+    });
 
-    QUnit.test( 'wrong values', function( assert ) {
+    QUnit.test('wrong values', function(assert) {
         var ready = assert.async();
         var provider;
 
-        assert.expect( 2 );
+        assert.expect(2);
 
-        provider = editorProvider( testConfig );
+        provider = editorProvider(testConfig);
 
-        provider.save( 'http://www.my-tao.com#blueprint1', { foo: true } ).then( function() {
-            assert.ok( false, 'The method must not resolve' );
+        provider.save('http://www.my-tao.com#blueprint1', {foo: true}).then(function() {
+            assert.ok(false, 'The method must not resolve');
             ready();
-        } ).catch( function( err ) {
-            assert.ok( err instanceof TypeError, 'The method rejects' );
-            assert.equal( err.message, 'The values parameter must be provided', 'The method rejects with the correct message' );
+        }).catch(function(err) {
+            assert.ok(err instanceof TypeError, 'The method rejects');
+            assert.equal(err.message, 'The values parameter must be provided', 'The method rejects with the correct message');
             ready();
-        } );
-    } );
+        });
+    });
 
-    QUnit.module( 'getSelection' );
+    QUnit.module('getSelection');
 
-    QUnit.test( 'success', function( assert ) {
+    QUnit.test('success', function(assert) {
         var ready = assert.async();
         var p;
-        var provider = editorProvider( testConfig );
+        var provider = editorProvider(testConfig);
 
-        assert.expect( 4 );
+        assert.expect(4);
 
-        p = provider.getSelection( 'http://www.my-tao.com#target-lang' );
+        p = provider.getSelection('http://www.my-tao.com#target-lang');
 
-        assert.ok( p instanceof Promise, 'The method returns a Promise' );
+        assert.ok(p instanceof Promise, 'The method returns a Promise');
 
-        p.then( function( data ) {
+        p.then(function(data) {
             var testUri = 'http://www.tao.lu/Ontologies/TAO.rdf#Langde-DE';
-            assert.equal( typeof data, 'object', 'The method resolve with an object' );
-            assert.equal( typeof data[ testUri ], 'object', 'The expected entry exists' );
-            assert.equal( data[ testUri ].label, 'German', 'The expected entry has the correct label' );
+            assert.equal(typeof data, 'object', 'The method resolve with an object');
+            assert.equal(typeof data[testUri], 'object', 'The expected entry exists');
+            assert.equal(data[testUri].label, 'German', 'The expected entry has the correct label');
             ready();
-        } ).catch( function( err ) {
-            assert.ok( false, 'The method should not reject : ' + err.message );
+        }).catch(function(err) {
+            assert.ok(false, 'The method should not reject : ' + err.message);
             ready();
-        } );
-    } );
+        });
+    });
 
-    QUnit.test( 'no uri', function( assert ) {
+    QUnit.test('no uri', function(assert) {
         var ready = assert.async();
         var provider;
 
-        assert.expect( 2 );
+        assert.expect(2);
 
-        provider = editorProvider( testConfig );
+        provider = editorProvider(testConfig);
 
-        provider.getSelection().then( function() {
-            assert.ok( false, 'The method must not resolve' );
+        provider.getSelection().then(function() {
+            assert.ok(false, 'The method must not resolve');
             ready();
-        } ).catch( function( err ) {
-            assert.ok( err instanceof TypeError, 'The method rejects' );
-            assert.equal( err.message, 'The property URI parameter must be provided', 'The method rejects with the correct message' );
+        }).catch(function(err) {
+            assert.ok(err instanceof TypeError, 'The method rejects');
+            assert.equal(err.message, 'The property URI parameter must be provided', 'The method rejects with the correct message');
             ready();
-        } );
-    } );
+        });
+    });
 
-} );
+});

--- a/views/js/test/provider/editor/test.js
+++ b/views/js/test/provider/editor/test.js
@@ -19,202 +19,209 @@
 /**
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-define([
+define( [
+    
     'taoBlueprints/provider/editor',
     'core/promise',
-    'json!taoBlueprints/test/provider/editor/saveSample.json',
-], function(editorProvider, Promise, saveSample) {
+    'json!taoBlueprints/test/provider/editor/saveSample.json'
+], function(  editorProvider, Promise, saveSample ) {
     'use strict';
 
     var testConfig = {
-        get : {
-            url : '/taoBlueprints/views/js/test/provider/editor/get.json'
+        get: {
+            url: '/taoBlueprints/views/js/test/provider/editor/get.json'
         },
-        save : {
-            url : '/taoBlueprints/views/js/test/provider/editor/save.json'
+        save: {
+            url: '/taoBlueprints/views/js/test/provider/editor/save.json'
         },
-        getSelection : {
-            url : '/taoBlueprints/views/js/test/provider/editor/getSelection.json'
+        getSelection: {
+            url: '/taoBlueprints/views/js/test/provider/editor/getSelection.json'
         }
     };
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('module', function(assert) {
-        QUnit.expect(3);
+    QUnit.test( 'module', function( assert ) {
+        assert.expect( 3 );
 
-        assert.equal(typeof editorProvider, 'function', "The editorProvider module exposes a function");
-        assert.equal(typeof editorProvider(), 'object', "The editorProvider factory produces an object");
-        assert.notStrictEqual(editorProvider(), editorProvider(), "The editorProvider factory provides a different object on each call");
-    });
+        assert.equal( typeof editorProvider, 'function', 'The editorProvider module exposes a function' );
+        assert.equal( typeof editorProvider(), 'object', 'The editorProvider factory produces an object' );
+        assert.notStrictEqual( editorProvider(), editorProvider(), 'The editorProvider factory provides a different object on each call' );
+    } );
 
-    QUnit.test('methods', function(assert) {
+    QUnit.test( 'methods', function( assert ) {
         var provider = editorProvider();
 
-        QUnit.expect(4);
+        assert.expect( 4 );
 
-        assert.equal(typeof provider, 'object', "The editorProvider factory produces an object");
-        assert.equal(typeof provider.get, 'function', "The provider exposes the get method");
-        assert.equal(typeof provider.save, 'function', "The provider exposes the save method");
-        assert.equal(typeof provider.getSelection, 'function', "The provider exposes the getSelection method");
-    });
+        assert.equal( typeof provider, 'object', 'The editorProvider factory produces an object' );
+        assert.equal( typeof provider.get, 'function', 'The provider exposes the get method' );
+        assert.equal( typeof provider.save, 'function', 'The provider exposes the save method' );
+        assert.equal( typeof provider.getSelection, 'function', 'The provider exposes the getSelection method' );
+    } );
 
-    QUnit.module('get');
+    QUnit.module( 'get' );
 
-    QUnit.asyncTest('success', function(assert) {
+    QUnit.test( 'success', function( assert ) {
+        var ready = assert.async();
         var p;
         var provider = editorProvider( testConfig );
 
-        QUnit.expect(3);
+        assert.expect( 3 );
 
-        p = provider.get('http://www.my-tao.com#blueprint1');
+        p = provider.get( 'http://www.my-tao.com#blueprint1' );
 
-        assert.ok(p instanceof Promise, 'The method returns a Promise');
+        assert.ok( p instanceof Promise, 'The method returns a Promise' );
 
-        p.then(function(data){
-            assert.equal(typeof data, 'object', 'The method resolve with an object');
-            assert.equal(data.property.uri, 'http://www.my-tao.com#topicArea', 'The method resolve with the correct object');
-            QUnit.start();
-        }).catch(function(err){
-            assert.ok(false, 'The method should not reject : ' + err.message);
-            QUnit.start();
-        });
-    });
+        p.then( function( data ) {
+            assert.equal( typeof data, 'object', 'The method resolve with an object' );
+            assert.equal( data.property.uri, 'http://www.my-tao.com#topicArea', 'The method resolve with the correct object' );
+            ready();
+        } ).catch( function( err ) {
+            assert.ok( false, 'The method should not reject : ' + err.message );
+            ready();
+        } );
+    } );
 
-    QUnit.asyncTest('no uri', function(assert) {
+    QUnit.test( 'no uri', function( assert ) {
+        var ready = assert.async();
         var provider;
 
-        QUnit.expect(2);
+        assert.expect( 2 );
 
         provider = editorProvider( testConfig );
 
-        provider.get().then(function(){
-            assert.ok(false, 'The method must not resolve');
-            QUnit.start();
-        }).catch(function(err){
-            assert.ok(err instanceof TypeError, 'The method rejects');
-            assert.equal(err.message, 'The blueprint URI parameter must be provided', 'The method rejects with the correct message');
-            QUnit.start();
-        });
-    });
+        provider.get().then( function() {
+            assert.ok( false, 'The method must not resolve' );
+            ready();
+        } ).catch( function( err ) {
+            assert.ok( err instanceof TypeError, 'The method rejects' );
+            assert.equal( err.message, 'The blueprint URI parameter must be provided', 'The method rejects with the correct message' );
+            ready();
+        } );
+    } );
 
-    QUnit.asyncTest('empty', function(assert) {
+    QUnit.test( 'empty', function( assert ) {
+        var ready = assert.async();
 
         var provider = editorProvider( {
-            get : {
-                url : '/taoBlueprints/views/js/test/provider/editor/empty.json'
+            get: {
+                url: '/taoBlueprints/views/js/test/provider/editor/empty.json'
             }
-        });
+        } );
 
-        QUnit.expect(1);
+        assert.expect( 1 );
 
-        provider.get('http://www.my-tao.com#blueprint1').then(function(data){
-            assert.equal(typeof data, 'undefined', 'The method resolve without content');
-            QUnit.start();
-        }).catch(function(err){
-            assert.ok(false, 'The method should not reject : ' + err.message);
-            QUnit.start();
-        });
-    });
+        provider.get( 'http://www.my-tao.com#blueprint1' ).then( function( data ) {
+            assert.equal( typeof data, 'undefined', 'The method resolve without content' );
+            ready();
+        } ).catch( function( err ) {
+            assert.ok( false, 'The method should not reject : ' + err.message );
+            ready();
+        } );
+    } );
 
+    QUnit.module( 'save' );
 
-    QUnit.module('save');
-
-    QUnit.asyncTest('success', function(assert) {
+    QUnit.test( 'success', function( assert ) {
+        var ready = assert.async();
         var p, provider;
 
-        QUnit.expect(2);
+        assert.expect( 2 );
 
         provider = editorProvider( testConfig );
-        p = provider.save('http://www.my-tao.com#blueprint1', saveSample);
+        p = provider.save( 'http://www.my-tao.com#blueprint1', saveSample );
 
-        assert.ok(p instanceof Promise, 'The method returns a Promise');
+        assert.ok( p instanceof Promise, 'The method returns a Promise' );
 
-        p.then(function(success){
+        p.then( function( success ) {
 
-            assert.ok(success, 'The save method succeed');
+            assert.ok( success, 'The save method succeed' );
 
-            QUnit.start();
-        }).catch(function(err){
-            assert.ok(false, 'The method should not reject : ' + err.message);
-            QUnit.start();
-        });
-    });
+            ready();
+        } ).catch( function( err ) {
+            assert.ok( false, 'The method should not reject : ' + err.message );
+            ready();
+        } );
+    } );
 
-    QUnit.asyncTest('no uri', function(assert) {
+    QUnit.test( 'no uri', function( assert ) {
+        var ready = assert.async();
         var provider;
 
-        QUnit.expect(2);
+        assert.expect( 2 );
 
         provider = editorProvider( testConfig );
 
-        provider.save().then(function(){
-            assert.ok(false, 'The method must not resolve');
-            QUnit.start();
-        }).catch(function(err){
-            assert.ok(err instanceof TypeError, 'The method rejects');
-            assert.equal(err.message, 'The blueprint URI parameter must be provided', 'The method rejects with the correct message');
-            QUnit.start();
-        });
-    });
+        provider.save().then( function() {
+            assert.ok( false, 'The method must not resolve' );
+            ready();
+        } ).catch( function( err ) {
+            assert.ok( err instanceof TypeError, 'The method rejects' );
+            assert.equal( err.message, 'The blueprint URI parameter must be provided', 'The method rejects with the correct message' );
+            ready();
+        } );
+    } );
 
-    QUnit.asyncTest('wrong values', function(assert) {
+    QUnit.test( 'wrong values', function( assert ) {
+        var ready = assert.async();
         var provider;
 
-        QUnit.expect(2);
+        assert.expect( 2 );
 
         provider = editorProvider( testConfig );
 
-        provider.save('http://www.my-tao.com#blueprint1', { foo : true }).then(function(){
-            assert.ok(false, 'The method must not resolve');
-            QUnit.start();
-        }).catch(function(err){
-            assert.ok(err instanceof TypeError, 'The method rejects');
-            assert.equal(err.message, 'The values parameter must be provided', 'The method rejects with the correct message');
-            QUnit.start();
-        });
-    });
+        provider.save( 'http://www.my-tao.com#blueprint1', { foo: true } ).then( function() {
+            assert.ok( false, 'The method must not resolve' );
+            ready();
+        } ).catch( function( err ) {
+            assert.ok( err instanceof TypeError, 'The method rejects' );
+            assert.equal( err.message, 'The values parameter must be provided', 'The method rejects with the correct message' );
+            ready();
+        } );
+    } );
 
+    QUnit.module( 'getSelection' );
 
-    QUnit.module('getSelection');
-
-    QUnit.asyncTest('success', function(assert) {
+    QUnit.test( 'success', function( assert ) {
+        var ready = assert.async();
         var p;
         var provider = editorProvider( testConfig );
 
-        QUnit.expect(4);
+        assert.expect( 4 );
 
-        p = provider.getSelection('http://www.my-tao.com#target-lang');
+        p = provider.getSelection( 'http://www.my-tao.com#target-lang' );
 
-        assert.ok(p instanceof Promise, 'The method returns a Promise');
+        assert.ok( p instanceof Promise, 'The method returns a Promise' );
 
-        p.then(function(data){
+        p.then( function( data ) {
             var testUri = 'http://www.tao.lu/Ontologies/TAO.rdf#Langde-DE';
-            assert.equal(typeof data, 'object', 'The method resolve with an object');
-            assert.equal(typeof data[testUri], 'object', 'The expected entry exists');
-            assert.equal(data[testUri].label, 'German', 'The expected entry has the correct label');
-            QUnit.start();
-        }).catch(function(err){
-            assert.ok(false, 'The method should not reject : ' + err.message);
-            QUnit.start();
-        });
-    });
+            assert.equal( typeof data, 'object', 'The method resolve with an object' );
+            assert.equal( typeof data[ testUri ], 'object', 'The expected entry exists' );
+            assert.equal( data[ testUri ].label, 'German', 'The expected entry has the correct label' );
+            ready();
+        } ).catch( function( err ) {
+            assert.ok( false, 'The method should not reject : ' + err.message );
+            ready();
+        } );
+    } );
 
-    QUnit.asyncTest('no uri', function(assert) {
+    QUnit.test( 'no uri', function( assert ) {
+        var ready = assert.async();
         var provider;
 
-        QUnit.expect(2);
+        assert.expect( 2 );
 
         provider = editorProvider( testConfig );
 
-        provider.getSelection().then(function(){
-            assert.ok(false, 'The method must not resolve');
-            QUnit.start();
-        }).catch(function(err){
-            assert.ok(err instanceof TypeError, 'The method rejects');
-            assert.equal(err.message, 'The property URI parameter must be provided', 'The method rejects with the correct message');
-            QUnit.start();
-        });
-    });
+        provider.getSelection().then( function() {
+            assert.ok( false, 'The method must not resolve' );
+            ready();
+        } ).catch( function( err ) {
+            assert.ok( err instanceof TypeError, 'The method rejects' );
+            assert.equal( err.message, 'The property URI parameter must be provided', 'The method rejects with the correct message' );
+            ready();
+        } );
+    } );
 
-});
+} );


### PR DESCRIPTION
**task** https://oat-sa.atlassian.net/browse/TAO-7629

 **description**  convert all unit tests for frontend part to latest Qunit 2 version. More details - in task.
 
**related PRs**
https://github.com/oat-sa/extension-tao-xmledit/pull/18
https://github.com/oat-sa/extension-tao-test/pull/273
https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/96
https://github.com/oat-sa/extension-tao-testcenter/pull/118
https://github.com/oat-sa/extension-tao-task-queue/pull/83
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/14
https://github.com/oat-sa/extension-tao-testqti/pull/1446
https://github.com/oat-sa/extension-tao-qtiprint/pull/56
https://github.com/oat-sa/extension-tao-itemqti/pull/1248
https://github.com/oat-sa/extension-tao-proctoring/pull/673
https://github.com/oat-sa/extension-tao-outcomeui/pull/254
https://github.com/oat-sa/extension-tao-item/pull/355
https://github.com/oat-sa/extension-tao-clientdiag/pull/223
https://github.com/oat-sa/extension-tao-booklet/pull/82
https://github.com/oat-sa/extension-tao-itemqti-pci/pull/147
https://github.com/oat-sa/extension-pcisample/pull/44