### PR TITLE
PHP 8 migration

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,27 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-version: [ '7.4', '8.0', '8.1' ]
+        include:
+          - php-version: '8.1'
+            coverage: true
+
+    steps:
+      - name: CI
+        uses: oat-sa/tao-extension-ci-action@v1
+        with:
+          php: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -25,3 +25,4 @@ jobs:
         with:
           php: ${{ matrix.php-version }}
           coverage: ${{ matrix.coverage }}
+          test-suites-path: test

--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,32 @@
 {
-
     "name": "oat-sa/extension-tao-blueprints",
-    "description" : "Extension to manage blue prints",
-    "type" : "tao-extension",
-    "authors" : [
+    "description": "Extension to manage blue prints",
+    "type": "tao-extension",
+    "authors": [
         {
-        "name": "Open Assessment Technologies SA"
+            "name": "Open Assessment Technologies SA"
         }
     ],
-    "keywords" : [
+    "keywords": [
         "tao",
         "computer-based-assessment"
     ],
-    "homepage" : "http://www.taotesting.com",
-    "license" : [
+    "homepage": "http://www.taotesting.com",
+    "license": [
         "GPL-2.0"
     ],
-    "extra" : {
-        "tao-extension-name" : "taoBlueprints"
+    "extra": {
+        "tao-extension-name": "taoBlueprints"
     },
-    "minimum-stability" : "dev",
+    "minimum-stability": "dev",
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis" : ">=14.0.0",
-        "oat-sa/tao-core" : ">=47.0.0"
+        "oat-sa/generis": ">=15.22",
+        "oat-sa/tao-core": ">=50.24.6"
     },
-    "autoload" : {
-        "psr-4" : {
-            "oat\\taoBlueprints\\" : ""
+    "autoload": {
+        "psr-4": {
+            "oat\\taoBlueprints\\": ""
         }
     }
 }


### PR DESCRIPTION
[ADF-1097](https://oat-sa.atlassian.net/browse/ADF-1097)
[ADF-1087](https://oat-sa.atlassian.net/browse/ADF-1087)
[ADF-1105](https://oat-sa.atlassian.net/browse/ADF-1105)

## Goal
Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.