### PR TITLE
fix: correct action bar icon order weights (AUT-4491)

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -16,30 +16,30 @@
 					/>
 				</trees>
 				<actions allowClassActions="true">
-					<action id="blueprint-new" name="New blueprint" url="/taoBlueprints/Blueprints/create" context="resource" group="tree" binding="instanciate">
-						<icon id="icon-item"/>
-					</action>
-					<action id="blueprint-class-properties" name="Properties" url="/taoBlueprints/Blueprints/editClassLabel" group="content" context="class">
-						<icon id="icon-edit"/>
-					</action>
-					<action id="blueprint-class-schema" name="Manage Schema" url="/taoBlueprints/Blueprints/editBlueprintClass" group="content" context="class">
-						<icon id="icon-property-add"/>
-					</action>
-					<action id="blueprint-properties" name="Properties"  url="/taoBlueprints/Blueprints/editInstance" group="content" context="instance">
-						<icon id="icon-edit"/>
-					</action>
-					<action id="blueprint-class-new" name="New class" url="/taoBlueprints/Blueprints/addSubClass" context="resource" group="tree" binding="subClass">
-						<icon id="icon-folder-open"/>
-					</action>
-					<action id="blueprint-delete" name="Delete" url="/taoBlueprints/Blueprints/delete" context="instance" group="tree" binding="removeNode" >
-						<icon id="icon-bin"/>
-					</action>
-					<action id="blueprint-class-delete" name="Delete" url="/taoBlueprints/Blueprints/deleteClass" context="class" group="tree" binding="removeNode" >
-						<icon id="icon-bin"/>
-					</action>
-					<action id="blueprint-move" name="Move" url="/taoBlueprints/Blueprints/moveInstance" context="instance" group="none" binding="moveNode">
-						<icon id="icon-move-item"/>
-					</action>
+				<action id="blueprint-new" name="New blueprint" url="/taoBlueprints/Blueprints/create" context="resource" group="tree" binding="instanciate" weight="1">
+					<icon id="icon-item"/>
+				</action>
+				<action id="blueprint-class-properties" name="Properties" url="/taoBlueprints/Blueprints/editClassLabel" group="content" context="class" weight="10">
+					<icon id="icon-edit"/>
+				</action>
+				<action id="blueprint-class-schema" name="Manage Schema" url="/taoBlueprints/Blueprints/editBlueprintClass" group="content" context="class" weight="3">
+					<icon id="icon-property-add"/>
+				</action>
+				<action id="blueprint-properties" name="Properties"  url="/taoBlueprints/Blueprints/editInstance" group="content" context="instance" weight="10">
+					<icon id="icon-edit"/>
+				</action>
+				<action id="blueprint-class-new" name="New class" url="/taoBlueprints/Blueprints/addSubClass" context="resource" group="tree" binding="subClass" weight="10">
+					<icon id="icon-folder-open"/>
+				</action>
+				<action id="blueprint-delete" name="Delete" url="/taoBlueprints/Blueprints/delete" context="instance" group="tree" binding="removeNode" weight="9">
+					<icon id="icon-bin"/>
+				</action>
+				<action id="blueprint-class-delete" name="Delete" url="/taoBlueprints/Blueprints/deleteClass" context="class" group="tree" binding="removeNode" weight="9">
+					<icon id="icon-bin"/>
+				</action>
+				<action id="blueprint-move" name="Move" url="/taoBlueprints/Blueprints/moveInstance" context="instance" group="none" binding="moveNode">
+					<icon id="icon-move-item"/>
+				</action>
 				</actions>
 			</section>
 		</sections>

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -19,13 +19,13 @@
 				<action id="blueprint-new" name="New blueprint" url="/taoBlueprints/Blueprints/create" context="resource" group="tree" binding="instanciate" weight="1">
 					<icon id="icon-item"/>
 				</action>
-				<action id="blueprint-class-properties" name="Properties" url="/taoBlueprints/Blueprints/editClassLabel" group="content" context="class" weight="10">
+				<action id="blueprint-class-properties" name="Properties" url="/taoBlueprints/Blueprints/editClassLabel" group="content" context="class" weight="1">
 					<icon id="icon-edit"/>
 				</action>
-				<action id="blueprint-class-schema" name="Manage Schema" url="/taoBlueprints/Blueprints/editBlueprintClass" group="content" context="class" weight="3">
+				<action id="blueprint-class-schema" name="Manage Schema" url="/taoBlueprints/Blueprints/editBlueprintClass" group="content" context="class" weight="8">
 					<icon id="icon-property-add"/>
 				</action>
-				<action id="blueprint-properties" name="Properties"  url="/taoBlueprints/Blueprints/editInstance" group="content" context="instance" weight="10">
+				<action id="blueprint-properties" name="Properties"  url="/taoBlueprints/Blueprints/editInstance" group="content" context="instance" weight="1">
 					<icon id="icon-edit"/>
 				</action>
 				<action id="blueprint-class-new" name="New class" url="/taoBlueprints/Blueprints/addSubClass" context="resource" group="tree" binding="subClass" weight="10">


### PR DESCRIPTION
# fix: correct action bar icon order weights (AUT-4491)

## Summary

- Adds missing `weight` attributes to all action definitions in `structures.xml` files across affected extensions.
- Fixes incorrect icon order in the Actions menu (all tabs) when the QuickWins design feature flag is enabled.
- Root cause: `getSortedActionsByWeight()` in `tao/helpers/Layout.php` sorts ascending by weight; weights were never consistently set when weight-based sorting was introduced in AUT-3938.

## Weight conventions applied

### Tree actions (lower = leftmost)
| Weight | Action type |
|--------|------------|
| 10 | New class |
| 9 | Delete (instance / class / all) |
| 8 | Import |
| 7 | Export / Publish |
| 6 | Duplicate |
| 5 | Copy To |
| 4 | Move To |
| 3 | Translate |
| 1 | New [entity] (primary create action) |

### Content actions
| Weight | Action type |
|--------|------------|
| 10 | Properties (instance / class) |
| 9 | Preview |
| 8 | Authoring |
| 7 | History |
| 6 | Usage |
| 5 | Item Statistics |
| 3 | Manage Schema |

## Impacted extensions

- `extension-tao-item` (taoItems)
- `extension-tao-itemqti` (taoQtiItem)
- `extension-tao-test` (taoTests)
- `extension-tao-testqti` (taoQtiTest)
- `extension-tao-group` (taoGroups)
- `extension-tao-testtaker` (taoTestTaker)
- `extension-tao-delivery-rdf` (taoDeliveryRdf)
- `extension-tao-deliver-connect` (taoDeliverConnect)
- `extension-tao-backoffice` (taoBackOffice)
- `extension-tao-outcomeui` (taoOutcomeUi)
- `extension-tao-proctoring` (taoProctoring)
- `extension-remote-proctoring` (remoteProctoring)
- `extension-tao-lti-consumer` (taoLtiConsumer)
- `extension-tao-testcenter` (taoTestCenter)
- `extension-tao-blueprints` (taoBlueprints)
- `extension-tao-mediamanager` (taoMediaManager)

## Testing

Enable the QuickWins design feature flag and verify the Actions toolbar icons appear in the correct order on all tabs (Items, Tests, Test-Takers, Groups, Deliveries, Results, Assets, Blueprints, Test Centers).

No code logic changes — XML `weight` attribute additions/corrections only.

## Related

- Jira: AUT-4491
- Introduced by: AUT-3938 (weight-based sort added to Layout.php)